### PR TITLE
feat: [NIC-77] Node port checking and notification

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -61,5 +61,7 @@
   "GetStarted": "Get started",
   "WelcomeToNiceNode": "Welcome to NiceNode",
   "WelcomeToNiceNodeDescription": "Run a node how you want it — without commands and a terminal. NiceNode shows what the node is doing at a glance. Stats like how many peer nodes are connected and synching progress are built into the app.",
-  "DeleteNodeDataQuestion": "Delete all of the node chain data?"
+  "DeleteNodeDataQuestion": "Delete all of the node chain data?",
+  "ResetNodeSettingsModal": "Reset node settings",
+  "ResetNodeSettingsQuestion": "Are you sure you want to reset all node settings to defaults?"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nice-node",
-  "version": "3.6.0-alpha",
+  "version": "3.6.2-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nice-node",
-      "version": "3.6.0-alpha",
+      "version": "3.6.2-alpha",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -17,7 +17,13 @@
       },
       "docker": {
         "containerVolumePath": "/var/lib/besu",
-        "raw": "-p 30303:30303/tcp -p 30303:30303/udp -p 8545:8545 -p 8546:8546 -p 8551:8551 --user 0",
+        "ports": {
+          "p2p": ["30303"],
+          "rest": "8545",
+          "ws": "8546",
+          "engine": "8551"
+        },
+        "raw": " --user 0",
         "forcedRawNodeInput": "--data-path=\"/var/lib/besu\" --engine-jwt-secret=\"/var/lib/besu/jwtsecret\""
       }
     }

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -75,7 +75,7 @@
       "documentation": "https://besu.hyperledger.org/en/stable/Concepts/Node-Types/"
     },
     "p2pPorts": {
-      "displayName": "P2P listening port (UDP and TCP)",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": "--p2p-port=",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -17,12 +17,6 @@
       },
       "docker": {
         "containerVolumePath": "/var/lib/besu",
-        "ports": {
-          "p2p": ["30303"],
-          "rest": "8545",
-          "ws": "8546",
-          "engine": "8551"
-        },
         "raw": " --user 0",
         "forcedRawNodeInput": "--data-path=\"/var/lib/besu\" --engine-jwt-secret=\"/var/lib/besu/jwtsecret\""
       }
@@ -80,6 +74,16 @@
       "defaultValue": "FAST",
       "documentation": "https://besu.hyperledger.org/en/stable/Concepts/Node-Types/"
     },
+    "p2pPorts": {
+      "displayName": "P2P listening port (UDP and TCP)",
+      "cliConfigPrefix": "--p2p-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 30303",
+      "defaultValue": "30303",
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#p2p-port"
+    },
     "http": {
       "displayName": "rpc http connections (*NiceNode requires http connections)",
       "category": "RPC APIs",
@@ -116,6 +120,15 @@
       "defaultValue": "Disabled",
       "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options/#engine-rpc-enabled"
     },
+    "enginePort": {
+      "displayName": "The listening port for the Engine API calls (ENGINE, ETH) for JSON-RPC over HTTP and WebSocket.",
+      "cliConfigPrefix": "--engine-rpc-port=",
+      "defaultValue": "8551",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#engine-rpc-port"
+    },
     "webSockets": {
       "displayName": "Enables or disables the WebSocket JSON-RPC service. The default is false.",
       "uiControl": {
@@ -150,6 +163,15 @@
       "uiControl": {
         "type": "text"
       }
+    },
+    "httpPort": {
+      "displayName": "HTTP-RPC server listening port",
+      "cliConfigPrefix": "--rpc-http-port=",
+      "defaultValue": "8545",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#rpc-http-port"
     },
     "httpApis": {
       "displayName": "Enabled certain HTTP APIs",

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -99,7 +99,7 @@
           }
         ]
       },
-      "defaultValue": "Disabled",
+      "defaultValue": "Enabled",
       "infoDescription": "NiceNode requires http connections",
       "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options#rpc-http-enabled"
     },
@@ -118,7 +118,7 @@
           }
         ]
       },
-      "defaultValue": "Disabled",
+      "defaultValue": "Enabled",
       "infoDescription": "Syncing requires this to be enabled",
       "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options#engine-rpc-enabled"
     },
@@ -146,7 +146,7 @@
           }
         ]
       },
-      "defaultValue": "Disabled",
+      "defaultValue": "Enabled",
       "infoDescription": "Enables or disables the WebSocket JSON-RPC service. The default is false.",
       "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#rpc-ws-enabled"
     },

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -52,7 +52,7 @@
       "uiControl": {
         "type": "filePath"
       },
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#data-path"
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#data-path"
     },
     "syncMode": {
       "displayName": "Node synchronization mode",
@@ -85,7 +85,7 @@
       "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#p2p-port"
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "category": "RPC APIs",
       "uiControl": {
         "type": "select/single",
@@ -100,10 +100,11 @@
         ]
       },
       "defaultValue": "Disabled",
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#rpc-http-enabled"
+      "infoDescription": "NiceNode requires http connections",
+      "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options#rpc-http-enabled"
     },
     "engineRpc": {
-      "displayName": "Engine RPC connections (*Syncing requires this enabled)",
+      "displayName": "Engine JSON-RPC connections",
       "category": "RPC API",
       "uiControl": {
         "type": "select/single",
@@ -118,19 +119,21 @@
         ]
       },
       "defaultValue": "Disabled",
-      "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options/#engine-rpc-enabled"
+      "infoDescription": "Syncing requires this to be enabled",
+      "documentation": "https://besu.hyperledger.org/en/stable/public-networks/reference/cli/options#engine-rpc-enabled"
     },
     "enginePort": {
-      "displayName": "The listening port for the Engine API calls (ENGINE, ETH) for JSON-RPC over HTTP and WebSocket.",
+      "displayName": "Engine JSON-RPC listening port",
       "cliConfigPrefix": "--engine-rpc-port=",
       "defaultValue": "8551",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "The listening port for the Engine API calls (ENGINE, ETH) for JSON-RPC over HTTP and WebSocket.",
       "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#engine-rpc-port"
     },
     "webSockets": {
-      "displayName": "Enables or disables the WebSocket JSON-RPC service. The default is false.",
+      "displayName": "WebSocket JSON-RPC connections",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
@@ -144,25 +147,27 @@
         ]
       },
       "defaultValue": "Disabled",
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#rpc-ws-enabled"
+      "infoDescription": "Enables or disables the WebSocket JSON-RPC service. The default is false.",
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#rpc-ws-enabled"
     },
     "webSocketsPort": {
-      "displayName": "The port (TCP) on which WebSocket JSON-RPC listens.",
+      "displayName": "WebSockets JSON-RPC port",
       "cliConfigPrefix": "--rpc-ws-port=",
       "defaultValue": "8546",
       "uiControl": {
         "type": "text"
       },
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#rpc-ws-port",
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#rpc-ws-port",
       "infoDescription": "The port (TCP) on which WebSocket JSON-RPC listens. The default is 8546. You must expose ports appropriately (https://besu.hyperledger.org/en/stable/HowTo/Find-and-Connect/Configuring-Ports/)."
     },
     "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls wrapped in double quotes)",
+      "displayName": "HTTP-RPC CORS domains",
       "cliConfigPrefix": "--rpc-http-cors-origins=",
       "valuesJoinStr": ",",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Change where the node accepts http connections (use comma separated urls wrapped in double quotes)"
     },
     "httpPort": {
       "displayName": "HTTP-RPC server listening port",
@@ -240,26 +245,26 @@
         ]
       },
       "defaultValue": ["ETH", "NET", "WEB3"],
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#rpc-http-api"
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#rpc-http-api"
     },
     "hostAllowList": {
-      "displayName": "A comma-separated list of hostnames to access the JSON-RPC API and pull Besu metrics. By default, Besu accepts requests from localhost and 127.0.0.1.",
+      "displayName": "JSON-RPC Host Allowlist",
       "category": "RPC APIs",
       "cliConfigPrefix": "--host-allowlist=",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Example value: medomain.com,meotherdomain.com",
+      "infoDescription": "A comma-separated list of hostnames to access the JSON-RPC API and pull Besu metrics. By default, Besu accepts requests from localhost and 127.0.0.1. Example value: medomain.com,meotherdomain.com",
       "defaultValue": "localhost,127.0.0.1"
     },
     "engineHostAllowList": {
-      "displayName": "A comma-separated list of hostnames to access the JSON-RPC API and pull Besu metrics. By default, Besu accepts requests from localhost and 127.0.0.1.",
+      "displayName": "Engine JSON-RPC Host Allowlist",
       "category": "RPC APIs",
       "cliConfigPrefix": "--engine-host-allowlist=",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Example value: medomain.com,meotherdomain.com",
+      "infoDescription": "A comma-separated list of hostnames to access the JSON-RPC API and pull Besu metrics. By default, Besu accepts requests from localhost and 127.0.0.1. Example value: medomain.com,meotherdomain.com",
       "defaultValue": "localhost,host.containers.internal,127.0.0.1"
     },
     "dataStorageFormat": {
@@ -280,16 +285,17 @@
         ]
       },
       "defaultValue": "FOREST",
-      "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#data-storage-format"
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#data-storage-format"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
-      "cliConfigPrefix": "--max-peers=",
+      "displayName": "Max Peer Count",
+      "cliConfigPrefix": ["--max-peers=", "--Xp2p-peer-lower-bound="],
       "defaultValue": "25",
       "uiControl": {
         "type": "text"
       },
-      "documentation": "https://besu.hyperledger.org/en/stable/HowTo/Find-and-Connect/Managing-Peers/#limit-peers"
+      "infoDescription": "Set to lower number to use less bandwidth",
+      "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#max-peers"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -162,7 +162,7 @@
     },
     "syncMode": {
       "displayName": "Node synchronization mode",
-      "infoDescription": "Blockchain sync mode (\"snap\", \"full\" or \"light\") (default: snap)",
+      "infoDescription": "Blockchain sync mode (\"snap\", \"full\") (default: snap)",
       "category": "Syncronization",
       "cliConfigPrefix": "--syncmode ",
       "uiControl": {
@@ -171,10 +171,6 @@
           {
             "value": "snap",
             "config": "snap"
-          },
-          {
-            "value": "light",
-            "config": "light"
           },
           {
             "value": "full",

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -16,7 +16,13 @@
       },
       "docker": {
         "containerVolumePath": "/root/.ethereum",
-        "raw": "-p 30303:30303/tcp -p 30303:30303/udp -p 8545:8545 -p 8546:8546 -p 8551:8551",
+        "ports": {
+          "p2p": ["30303"],
+          "rest": "8545",
+          "ws": "8546",
+          "engine": "8551"
+        },
+        "raw": "",
         "forcedRawNodeInput": "--http.addr 0.0.0.0 --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /root/.ethereum/jwtsecret --ipcdisable"
       }
     },

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -16,12 +16,6 @@
       },
       "docker": {
         "containerVolumePath": "/root/.ethereum",
-        "ports": {
-          "p2p": ["30303"],
-          "rest": "8545",
-          "ws": "8546",
-          "engine": "8551"
-        },
         "raw": "",
         "forcedRawNodeInput": "--http.addr 0.0.0.0 --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /root/.ethereum/jwtsecret --ipcdisable"
       }
@@ -110,6 +104,15 @@
       "defaultValue": "Disabled",
       "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
     },
+    "webSocketsPort": {
+      "displayName": "WS-RPC server listening port",
+      "cliConfigPrefix": "--ws.port ",
+      "defaultValue": "8546",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
+    },
     "httpApis": {
       "displayName": "Enabled HTTP APIs",
       "cliConfigPrefix": "--http.api ",
@@ -178,6 +181,23 @@
       "defaultValue": "snap",
       "documentation": "https://geth.ethereum.org/docs/faq#how-does-ethereum-syncing-work"
     },
+    "p2pPorts": {
+      "displayName": "Use a custom UDP port for P2P discovery",
+      "cliConfigPrefix": "--discovery.port ",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 30303",
+      "defaultValue": "30303"
+    },
+    "enginePort": {
+      "displayName": "Listening port for authenticated APIs",
+      "cliConfigPrefix": "--authrpc.port ",
+      "defaultValue": "8551",
+      "uiControl": {
+        "type": "text"
+      }
+    },
     "httpVirtualHosts": {
       "displayName": "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. Default value (localhost)",
       "cliConfigPrefix": "--http.vhosts ",
@@ -203,15 +223,6 @@
         "type": "text"
       },
       "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
-    },
-    "webSocketsPort": {
-      "displayName": "WS-RPC server listening port",
-      "cliConfigPrefix": "--ws.port ",
-      "defaultValue": "8546",
-      "uiControl": {
-        "type": "text"
-      },
-      "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
     },
     "lightModeMaxPeerCount": {
       "displayName": "Light Mode Max Peer Count (set to low number to use less bandwidth)",

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -230,15 +230,6 @@
       },
       "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
     },
-    "lightModeMaxPeerCount": {
-      "displayName": "Light Mode Max Peer Count",
-      "cliConfigPrefix": "--light.maxpeers ",
-      "defaultValue": "100",
-      "uiControl": {
-        "type": "text"
-      },
-      "infoDescription": "Set to lower number to use less bandwidth"
-    },
     "maxPeerCount": {
       "displayName": "Max Peer Count",
       "cliConfigPrefix": "--maxpeers ",

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -182,7 +182,7 @@
       "documentation": "https://geth.ethereum.org/docs/faq#how-does-ethereum-syncing-work"
     },
     "p2pPorts": {
-      "displayName": "Use a custom UDP port for P2P discovery",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": "--discovery.port ",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -71,7 +71,7 @@
       "infoDescription": "Data directory for the databases and keystore (default: \"~/.ethereum\")"
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
@@ -85,10 +85,11 @@
         ]
       },
       "defaultValue": "Disabled",
+      "infoDescription": "NiceNode requires http connections",
       "documentation": "https://geth.ethereum.org/docs/rpc/server"
     },
     "webSockets": {
-      "displayName": "rpc websocket connections (*BeaconNodes may require websocket connections)",
+      "displayName": "WebSocket JSON-RPC connections",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
@@ -102,15 +103,17 @@
         ]
       },
       "defaultValue": "Disabled",
+      "infoDescription": "Enables or disables the WebSocket JSON-RPC service. Beacon nodes may require websockets. The default is false.",
       "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
     },
     "webSocketsPort": {
-      "displayName": "WS-RPC server listening port",
+      "displayName": "WebSockets JSON-RPC port",
       "cliConfigPrefix": "--ws.port ",
       "defaultValue": "8546",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "The port (TCP) on which WebSocket JSON-RPC listens. The default is 8546. You must expose ports appropriately.",
       "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
     },
     "httpApis": {
@@ -150,11 +153,12 @@
       }
     },
     "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls)",
+      "displayName": "HTTP-RPC CORS domains",
       "cliConfigPrefix": "--http.corsdomain ",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Change where the node accepts http connections (use comma separated urls)"
     },
     "syncMode": {
       "displayName": "Node synchronization mode",
@@ -191,19 +195,21 @@
       "defaultValue": "30303"
     },
     "enginePort": {
-      "displayName": "Listening port for authenticated APIs",
+      "displayName": "Engine JSON-RPC listening port",
       "cliConfigPrefix": "--authrpc.port ",
       "defaultValue": "8551",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "The listening port for the Engine API calls for JSON-RPC over HTTP and WebSocket."
     },
     "httpVirtualHosts": {
-      "displayName": "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. Default value (localhost)",
+      "displayName": "Virtual hostnames list",
       "cliConfigPrefix": "--http.vhosts ",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. Default value (localhost)",
       "defaultValue": "localhost,host.containers.internal"
     },
     "httpAddress": {
@@ -225,28 +231,31 @@
       "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
     },
     "lightModeMaxPeerCount": {
-      "displayName": "Light Mode Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Light Mode Max Peer Count",
       "cliConfigPrefix": "--light.maxpeers ",
       "defaultValue": "100",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Set to lower number to use less bandwidth"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--maxpeers ",
       "defaultValue": "50",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Set to lower number to use less bandwidth",
       "documentation": "https://geth.ethereum.org/docs/interface/peer-to-peer#peer-limit"
     },
     "authVirtualHosts": {
-      "displayName": "Comma separated list of virtual hostnames from which to accept authentication requests for engine api's (server enforced). Accepts '*' wildcard. Default value (localhost)",
+      "displayName": "Engine RPC virtual hostnames list",
       "cliConfigPrefix": "--authrpc.vhosts ",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Comma separated list of virtual hostnames from which to accept authentication requests for engine api's (server enforced). Accepts '*' wildcard. Default value (localhost)",
       "defaultValue": "localhost,host.containers.internal"
     }
   },

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -16,10 +16,6 @@
       },
       "docker": {
         "containerVolumePath": "/root/.lighthouse",
-        "ports": {
-          "p2p": ["9000"],
-          "rest": "5052"
-        },
         "raw": "",
         "forcedRawNodeInput": "lighthouse --network mainnet beacon --execution-jwt /root/.lighthouse/jwtsecret"
       }
@@ -91,6 +87,16 @@
       },
       "defaultValue": "Disabled",
       "documentation": "https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server"
+    },
+    "p2pPorts": {
+      "displayName": "P2P listening port (UDP and TCP)",
+      "cliConfigPrefix": "--port ",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 9000",
+      "defaultValue": "9000",
+      "documentation": "https://lighthouse-book.sigmaprime.io/faq.html?highlight=9000#how-to-change-the-tcpudp-port-9000-that-lighthouse-listens-on"
     },
     "httpHostAddress": {
       "displayName": "Listening address of the REST server.",

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -16,7 +16,11 @@
       },
       "docker": {
         "containerVolumePath": "/root/.lighthouse",
-        "raw": "-p 9000:9000/tcp -p 9000:9000/udp -p 127.0.0.1:5052:5052",
+        "ports": {
+          "p2p": ["9000"],
+          "rest": "5052"
+        },
+        "raw": "",
         "forcedRawNodeInput": "lighthouse --network mainnet beacon --execution-jwt /root/.lighthouse/jwtsecret"
       }
     },

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -90,7 +90,7 @@
       "documentation": "https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server"
     },
     "p2pPorts": {
-      "displayName": "P2P listening port (UDP and TCP)",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": "--port ",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -64,7 +64,7 @@
       "documentation": "https://lighthouse-book.sigmaprime.io/advanced-datadir.html?highlight=--datadir#relative-paths"
     },
     "checkpointSyncUrl": {
-      "displayName": "The URL of a trusted checkpoint sync",
+      "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpoint-sync-url ",
       "defaultValue": "https://mainnet.checkpoint.sigp.io",
       "uiControl": {
@@ -72,7 +72,7 @@
       }
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
@@ -86,6 +86,7 @@
         ]
       },
       "defaultValue": "Disabled",
+      "infoDescription": "NiceNode requires http connections",
       "documentation": "https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server"
     },
     "p2pPorts": {
@@ -99,7 +100,7 @@
       "documentation": "https://lighthouse-book.sigmaprime.io/faq.html?highlight=9000#how-to-change-the-tcpudp-port-9000-that-lighthouse-listens-on"
     },
     "httpHostAddress": {
-      "displayName": "Listening address of the REST server.",
+      "displayName": "REST server listening address",
       "cliConfigPrefix": "--http-address ",
       "defaultValue": "127.0.0.1",
       "uiControl": {
@@ -108,7 +109,7 @@
       "infoDescription": "Limit the access to the REST API to a particular hostname (for CORS-enabled clients such as browsers)."
     },
     "httpPort": {
-      "displayName": "Set port for HTTP API",
+      "displayName": "HTTP-RPC server listening port",
       "cliConfigPrefix": "--http-port ",
       "defaultValue": "5052",
       "uiControl": {
@@ -117,16 +118,16 @@
       "documentation": "https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server"
     },
     "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls)",
+      "displayName": "HTTP-RPC CORS domains",
       "cliConfigPrefix": "--http-allow-origin ",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Set the value of the Access-Control-Allow-Origin response HTTP header. Use * to allow any origin (not recommended in production). If no value is supplied, the CORS allowed origin is set to the listen address of this server (e.g., http://localhost:5052)",
+      "infoDescription": "Set the value of the Access-Control-Allow-Origin response HTTP header (use comma separated urls) Use * to allow any origin (not recommended in production). If no value is supplied, the CORS allowed origin is set to the listen address of this server (e.g., http://localhost:5052)",
       "documentation": "https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server"
     },
     "executionEndpoint": {
-      "displayName": "The URL of the local execution engine API",
+      "displayName": "Local execution Engine RPC-JSON API URL",
       "cliConfigPrefix": "--execution-endpoint ",
       "defaultValue": "http://host.containers.internal:8551",
       "uiControl": {
@@ -135,11 +136,12 @@
       "documentation": "https://lighthouse-book.sigmaprime.io/run_a_node.html#step-3-set-up-a-beacon-node-using-lighthouse"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--target-peers ",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Set to lower number to use less bandwidth",
       "documentation": "https://lighthouse-book.sigmaprime.io/advanced_networking.html#target-peers"
     }
   },

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -15,7 +15,11 @@
       },
       "docker": {
         "containerVolumePath": "/usr/app/data",
-        "raw": "-p 9000:9000/tcp -p 9000:9000/udp -p 5052:5052",
+        "ports": {
+          "p2p": ["9000"],
+          "rest": "9596"
+        },
+        "raw": "",
         "forcedRawNodeInput": "beacon --network mainnet --rest.address 0.0.0.0 --dataDir /usr/app/data --jwt-secret /usr/app/data/jwtsecret"
       }
     }

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -15,10 +15,6 @@
       },
       "docker": {
         "containerVolumePath": "/usr/app/data",
-        "ports": {
-          "p2p": ["9000"],
-          "rest": "9596"
-        },
         "raw": "",
         "forcedRawNodeInput": "beacon --network mainnet --rest.address 0.0.0.0 --dataDir /usr/app/data --jwt-secret /usr/app/data/jwtsecret"
       }
@@ -113,6 +109,15 @@
         ]
       }
     },
+    "p2pPorts": {
+      "displayName": "P2P listening port (UDP and TCP)",
+      "cliConfigPrefix": "--port ",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 9000",
+      "defaultValue": "9000"
+    },
     "httpHostAddress": {
       "displayName": "Listening address of the REST server.",
       "cliConfigPrefix": "--rest.address ",
@@ -125,7 +130,7 @@
     "httpPort": {
       "displayName": "Set port for HTTP API",
       "cliConfigPrefix": "--rest.port ",
-      "defaultValue": "5052",
+      "defaultValue": "9596",
       "uiControl": {
         "type": "text"
       }

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -52,7 +52,7 @@
       "infoDescription": "Lodestar root directory"
     },
     "checkpointSyncUrl": {
-      "displayName": "The URL of a trusted checkpoint sync",
+      "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpointSyncUrl ",
       "defaultValue": "https://beaconstate-mainnet.chainsafe.io",
       "uiControl": {
@@ -60,7 +60,7 @@
       }
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "cliConfigPrefix": "--rest ",
       "uiControl": {
         "type": "select/single",
@@ -75,10 +75,11 @@
           }
         ]
       },
+      "infoDescription": "NiceNode requires http connections",
       "defaultValue": "Disabled"
     },
     "httpApis": {
-      "displayName": "Pick namespaces to expose for HTTP API",
+      "displayName": "Enabled HTTP namespaces",
       "cliConfigPrefix": "--rest.namespace ",
       "defaultValue": ["beacon", "config", "events", "node", "validator"],
       "valuesJoinStr": ",",
@@ -119,7 +120,7 @@
       "defaultValue": "9000"
     },
     "httpHostAddress": {
-      "displayName": "Listening address of the REST server.",
+      "displayName": "REST server listening address",
       "cliConfigPrefix": "--rest.address ",
       "defaultValue": "0.0.0.0",
       "uiControl": {
@@ -128,7 +129,7 @@
       "infoDescription": "Limit the access to the REST API to a particular hostname (for CORS-enabled clients such as browsers)."
     },
     "httpPort": {
-      "displayName": "Set port for HTTP API",
+      "displayName": "HTTP-RPC server listening port",
       "cliConfigPrefix": "--rest.port ",
       "defaultValue": "9596",
       "uiControl": {
@@ -136,15 +137,16 @@
       }
     },
     "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls)",
+      "displayName": "HTTP-RPC CORS domains",
       "cliConfigPrefix": "--http.corsdomain ",
       "defaultValue": "*",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Change where the node accepts http connections (use comma separated urls)"
     },
     "executionEndpoint": {
-      "displayName": "The URL of the local execution engine API",
+      "displayName": "Local execution Engine RPC-JSON API URL",
       "cliConfigPrefix": "--execution.urls ",
       "defaultValue": "http://localhost:8551",
       "uiControl": {
@@ -152,12 +154,13 @@
       }
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--network.maxPeers ",
       "defaultValue": "55",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Set to lower number to use less bandwidth"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -111,7 +111,7 @@
       }
     },
     "p2pPorts": {
-      "displayName": "P2P listening port (UDP and TCP)",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": "--port ",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -12,7 +12,13 @@
         "webSocketsPort": "8546"
       },
       "docker": {
-        "raw": " -p 30303:30303/tcp -p 30303:30303/udp -p 8545:8545 -p 8546:8546 -p 8551:8551",
+        "ports": {
+          "p2p": ["30303"],
+          "rest": "8545",
+          "ws": "8546",
+          "engine": "8551"
+        },
+        "raw": "",
         "containerVolumePath": "/nethermind/data",
         "forcedRawNodeInput": "--datadir /nethermind/data --JsonRpc.Host 0.0.0.0 --JsonRpc.EngineHost 0.0.0.0 --JsonRpc.EnginePort 8551 --JsonRpc.JwtSecretFile=/nethermind/data/jwtsecret"
       }

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -62,7 +62,7 @@
       }
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "category": "RPC APIs",
       "cliConfigPrefix": "--JsonRpc.Enabled ",
       "uiControl": {
@@ -77,7 +77,8 @@
           }
         ]
       },
-      "defaultValue": "Disabled",
+      "infoDescription": "NiceNode requires http connections",
+      "defaultValue": "Enabled",
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/json-rpc"
     },
     "p2pPorts": {
@@ -91,12 +92,13 @@
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/network"
     },
     "enginePort": {
-      "displayName": "Port for Execution Engine calls. Ensure the firewall is configured when enabling JSON RPC.",
+      "displayName": "Engine JSON-RPC listening port",
       "cliConfigPrefix": "--JsonRpc.EnginePort ",
       "defaultValue": "8551",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Ensure the firewall is configured when enabling JSON RPC.",
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/jsonrpc"
     },
     "httpPort": {
@@ -193,7 +195,7 @@
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/sync-modes"
     },
     "webSocketsPort": {
-      "displayName": "Port number for JSON RPC web sockets calls",
+      "displayName": "WebSockets JSON-RPC port",
       "cliConfigPrefix": "--JsonRpc.WebSocketsPort ",
       "defaultValue": "8545",
       "niceNodeDefaultValue": "8545",
@@ -204,12 +206,13 @@
       "infoDescription": "Port number for JSON RPC web sockets calls. By default same port is used as regular HTTP JSON RPC. Ensure the firewall is configured when enabling JSON RPC."
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--Network.ActivePeersMaxCount ",
       "defaultValue": "50",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Set to lower number to use less bandwidth",
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/network"
     }
   },

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -9,12 +9,13 @@
       "defaultConfig": {
         "http": "Enabled",
         "syncMode": "snap",
-        "webSocketsPort": "8546"
+        "webSocketsPort": "8546",
+        "enginePort": "8551"
       },
       "docker": {
         "raw": "",
         "containerVolumePath": "/nethermind/data",
-        "forcedRawNodeInput": "--datadir /nethermind/data --JsonRpc.Host 0.0.0.0 --JsonRpc.EngineHost 0.0.0.0 --JsonRpc.EnginePort 8551 --JsonRpc.JwtSecretFile=/nethermind/data/jwtsecret"
+        "forcedRawNodeInput": "--datadir /nethermind/data --JsonRpc.Host 0.0.0.0 --JsonRpc.EngineHost 0.0.0.0 --JsonRpc.JwtSecretFile=/nethermind/data/jwtsecret"
       }
     },
     "architectures": {

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -82,8 +82,7 @@
     },
     "p2pPorts": {
       "displayName": "P2P listening port (UDP and TCP)",
-      "cliConfigPrefix": "--Network.P2PPort ",
-      "secondaryCliConfigPrefix": "--Network.DiscoveryPort ",
+      "cliConfigPrefix": ["--Network.P2PPort ", "--Network.DiscoveryPort "],
       "uiControl": {
         "type": "text"
       },

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -12,12 +12,6 @@
         "webSocketsPort": "8546"
       },
       "docker": {
-        "ports": {
-          "p2p": ["30303"],
-          "rest": "8545",
-          "ws": "8546",
-          "engine": "8551"
-        },
         "raw": "",
         "containerVolumePath": "/nethermind/data",
         "forcedRawNodeInput": "--datadir /nethermind/data --JsonRpc.Host 0.0.0.0 --JsonRpc.EngineHost 0.0.0.0 --JsonRpc.EnginePort 8551 --JsonRpc.JwtSecretFile=/nethermind/data/jwtsecret"
@@ -84,6 +78,35 @@
         ]
       },
       "defaultValue": "Disabled",
+      "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/json-rpc"
+    },
+    "p2pPorts": {
+      "displayName": "P2P listening port (UDP and TCP)",
+      "cliConfigPrefix": "--Network.P2PPort ",
+      "secondaryCliConfigPrefix": "--Network.DiscoveryPort ",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 30303",
+      "defaultValue": "30303",
+      "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/network"
+    },
+    "enginePort": {
+      "displayName": "Port for Execution Engine calls. Ensure the firewall is configured when enabling JSON RPC.",
+      "cliConfigPrefix": "--JsonRpc.EnginePort ",
+      "defaultValue": "8551",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/jsonrpc"
+    },
+    "httpPort": {
+      "displayName": "HTTP-RPC server listening port",
+      "cliConfigPrefix": "--JsonRpc.Port ",
+      "defaultValue": "8545",
+      "uiControl": {
+        "type": "text"
+      },
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/json-rpc"
     },
     "httpApis": {
@@ -174,7 +197,7 @@
       "displayName": "Port number for JSON RPC web sockets calls",
       "cliConfigPrefix": "--JsonRpc.WebSocketsPort ",
       "defaultValue": "8545",
-      "niceNodeDefaultValue": "8546",
+      "niceNodeDefaultValue": "8545",
       "uiControl": {
         "type": "text"
       },

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -82,7 +82,7 @@
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/json-rpc"
     },
     "p2pPorts": {
-      "displayName": "P2P listening port (UDP and TCP)",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": ["--Network.P2PPort ", "--Network.DiscoveryPort "],
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -55,7 +55,7 @@
       "documentation": "https://nimbus.guide/options.html"
     },
     "checkpointSyncUrl": {
-      "displayName": "The URL of a trusted checkpoint sync",
+      "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--trusted-node-url=",
       "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
@@ -83,7 +83,7 @@
       "documentation": "https://nimbus.guide/options.html"
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
@@ -96,10 +96,11 @@
           }
         ]
       },
-      "defaultValue": "Disabled"
+      "infoDescription": "NiceNode requires http connections",
+      "defaultValue": "Enabled"
     },
     "httpPort": {
-      "displayName": "Set port for HTTP API",
+      "displayName": "HTTP-RPC server listening port",
       "cliConfigPrefix": "--rest-port=",
       "defaultValue": "5052",
       "uiControl": {
@@ -107,15 +108,15 @@
       }
     },
     "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls)",
+      "displayName": "HTTP-RPC CORS domains",
       "cliConfigPrefix": "--rest-allow-origin=",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Limit the access to the REST API to a particular hostname (for CORS-enabled clients such as browsers)."
+      "infoDescription": "Limit the access to the REST API to a particular hostname (for CORS-enabled clients such as browsers) Use comma separated URLs."
     },
     "httpHostAddress": {
-      "displayName": "Listening address of the REST server.",
+      "displayName": "REST server listening address",
       "cliConfigPrefix": "--rest-address=",
       "defaultValue": "127.0.0.1",
       "uiControl": {
@@ -124,22 +125,23 @@
       "infoDescription": "Limit the access to the REST API to a particular hostname (for CORS-enabled clients such as browsers)."
     },
     "executionEndpoint": {
-      "displayName": "One or more execution layer Web3 provider URLs",
+      "displayName": "Local execution Engine RPC-JSON API URL",
       "cliConfigPrefix": "--web3-url=",
       "defaultValue": "\"http://host.containers.internal:8551\"",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "informs the beacon node how to connect to the execution client - both http:// and ws:// URLs are supported.",
+      "infoDescription": "Informs the beacon node how to connect to the execution client - both http:// and ws:// URLs are supported.",
       "documentation": "https://nimbus.guide/eth1.html#3-pass-the-url-and-jwt-secret-to-nimbus"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--max-peers=",
       "defaultValue": "160",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Set to lower number to use less bandwidth"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -73,7 +73,7 @@
       "documentation": "https://nimbus.guide/options.html"
     },
     "p2pPortsUdp": {
-      "displayName": "P2P listening port (UDP)",
+      "displayName": "P2P discovery port (UDP)",
       "cliConfigPrefix": "--udp-port=",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -9,13 +9,18 @@
     "input": {
       "defaultConfig": {
         "http": "Enabled",
+        "httpPort": "5052",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "\"http://host.containers.internal:8551\""
       },
       "docker": {
         "containerVolumePath": "/home/user/data",
-        "raw": "-p 9000:9000/tcp -p 9000:9000/udp -p 5052:5052 --user 0",
+        "ports": {
+          "p2p": ["9000"],
+          "rest": "5052"
+        },
+        "raw": " --user 0",
         "forcedRawNodeInput": "--data-dir=/home/user/data/beacon_node/mainnet_0 --network=mainnet --web3-url=http://host.containers.internal:8551 --jwt-secret=/home/user/data/jwtsecret"
       }
     },

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -16,10 +16,6 @@
       },
       "docker": {
         "containerVolumePath": "/home/user/data",
-        "ports": {
-          "p2p": ["9000"],
-          "rest": "5052"
-        },
         "raw": " --user 0",
         "forcedRawNodeInput": "--data-dir=/home/user/data/beacon_node/mainnet_0 --network=mainnet --web3-url=http://host.containers.internal:8551 --jwt-secret=/home/user/data/jwtsecret"
       }
@@ -65,6 +61,26 @@
       "uiControl": {
         "type": "text"
       }
+    },
+    "p2pPortsTcp": {
+      "displayName": "P2P listening port (TCP)",
+      "cliConfigPrefix": "--tcp-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 9000",
+      "defaultValue": "9000",
+      "documentation": "https://nimbus.guide/options.html"
+    },
+    "p2pPortsUdp": {
+      "displayName": "P2P listening port (UDP)",
+      "cliConfigPrefix": "--udp-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 9000",
+      "defaultValue": "9000",
+      "documentation": "https://nimbus.guide/options.html"
     },
     "http": {
       "displayName": "rpc http connections (*NiceNode requires http connections)",

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -9,17 +9,13 @@
     "input": {
       "defaultConfig": {
         "http": "Enabled",
-        "httpPort": "5051",
+        "httpPort": "3500",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "http://host.containers.internal:8551",
         "checkpointSyncUrl": "https://beaconstate.ethstaker.cc"
       },
       "docker": {
-        "ports": {
-          "p2p": ["13000,12000"],
-          "rest": "5051"
-        },
         "containerVolumePath": "/data",
         "raw": "",
         "forcedRawNodeInput": "--accept-terms-of-use=true --datadir=/data --rpc-host=0.0.0.0 --jwt-secret=/data/jwtsecret"
@@ -65,6 +61,26 @@
       "uiControl": {
         "type": "text"
       }
+    },
+    "p2pPortsTcp": {
+      "displayName": "P2P listening port (TCP)",
+      "cliConfigPrefix": "--tcp-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 13000",
+      "defaultValue": "13000",
+      "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters"
+    },
+    "p2pPortsUdp": {
+      "displayName": "P2P listening port (UDP)",
+      "cliConfigPrefix": "--udp-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 12000",
+      "defaultValue": "12000",
+      "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters"
     },
     "httpPort": {
       "displayName": "The host on which the gateway server runs on",

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -55,7 +55,7 @@
       "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters/"
     },
     "checkpointSyncUrl": {
-      "displayName": "The URL of a trusted checkpoint sync",
+      "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpoint-sync-url=",
       "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
@@ -83,7 +83,7 @@
       "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters"
     },
     "httpPort": {
-      "displayName": "The host on which the gateway server runs on",
+      "displayName": "Gateway server listening port",
       "cliConfigPrefix": "--grpc-gateway-port=",
       "defaultValue": "3500",
       "uiControl": {
@@ -91,14 +91,15 @@
       }
     },
     "httpCorsDomains": {
-      "displayName": "Comma separated list of domains from which to accept cross origin requests (browser enforced). This flag has no effect if not used with --grpc-gateway-port.",
+      "displayName": "Gateway CORS domains",
       "cliConfigPrefix": "--grpc-gateway-corsdomain=",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Comma separated list of domains from which to accept cross origin requests (browser enforced). This flag has no effect if not used with --grpc-gateway-port."
     },
     "httpHostAddress": {
-      "displayName": "The host on which the gateway server runs on",
+      "displayName": "Gateway host listening address",
       "cliConfigPrefix": "--grpc-gateway-host=",
       "defaultValue": "0.0.0.0",
       "uiControl": {
@@ -106,7 +107,7 @@
       }
     },
     "executionEndpoint": {
-      "displayName": "The URL of the local execution engine API",
+      "displayName": "Local execution Engine RPC-JSON API URL",
       "cliConfigPrefix": "--execution-endpoint=",
       "defaultValue": "http://host.containers.internal:8551",
       "uiControl": {
@@ -115,12 +116,13 @@
       "iconUrl": "https://docs.prylabs.network/docs/execution-node/authentication#configure-beacon-node"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--p2p-max-peers=",
       "defaultValue": "45",
       "uiControl": {
         "type": "text"
-      }
+      },
+      "infoDescription": "Set to lower number to use less bandwidth"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -73,7 +73,7 @@
       "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters"
     },
     "p2pPortsUdp": {
-      "displayName": "P2P listening port (UDP)",
+      "displayName": "P2P discovery port (UDP)",
       "cliConfigPrefix": "--udp-port=",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -9,15 +9,19 @@
     "input": {
       "defaultConfig": {
         "http": "Enabled",
-        "httpPort": "5052",
+        "httpPort": "5051",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "http://host.containers.internal:8551",
         "checkpointSyncUrl": "https://beaconstate.ethstaker.cc"
       },
       "docker": {
+        "ports": {
+          "p2p": ["13000,12000"],
+          "rest": "5051"
+        },
         "containerVolumePath": "/data",
-        "raw": "-p 5052:5052 -p 13000:13000 -p 12000:12000/udp",
+        "raw": "",
         "forcedRawNodeInput": "--accept-terms-of-use=true --datadir=/data --rpc-host=0.0.0.0 --jwt-secret=/data/jwtsecret"
       }
     }

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -55,7 +55,7 @@
       "documentation": "https://docs.teku.consensys.net/en/stable/Reference/CLI/CLI-Syntax/#data-base-path-data-path"
     },
     "checkpointSyncUrl": {
-      "displayName": "The URL of a trusted checkpoint sync",
+      "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--initial-state=",
       "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
@@ -73,7 +73,7 @@
       "documentation": "https://docs.teku.consensys.net/reference/cli#p2p-port"
     },
     "http": {
-      "displayName": "rpc http connections (*NiceNode requires http connections)",
+      "displayName": "RPC HTTP connections",
       "cliConfigPrefix": "--rest-api-enabled=",
       "uiControl": {
         "type": "select/single",
@@ -88,11 +88,12 @@
           }
         ]
       },
-      "defaultValue": "Disabled",
+      "defaultValue": "Enabled",
+      "infoDescription": "NiceNode requires http connections",
       "documentation": "https://docs.teku.consensys.net/en/stable/Reference/CLI/CLI-Syntax/#rest-api-enabled"
     },
     "httpPort": {
-      "displayName": "Specifies REST API listening port (HTTP).",
+      "displayName": "HTTP server listening port",
       "cliConfigPrefix": "--rest-api-port=",
       "defaultValue": "5051",
       "uiControl": {
@@ -101,7 +102,7 @@
       "documentation": "https://docs.teku.consensys.net/en/stable/Reference/CLI/CLI-Syntax/#rest-api-port"
     },
     "httpCorsDomains": {
-      "displayName": "A comma-separated list of hostnames to allow access to the REST API.",
+      "displayName": "HTTP CORS domains",
       "cliConfigPrefix": "--rest-api-cors-origins=",
       "defaultValue": "none",
       "uiControl": {
@@ -112,22 +113,22 @@
       "documentation": "https://docs.teku.consensys.net/en/stable/Reference/CLI/CLI-Syntax/#rest-api-host-allowlist"
     },
     "executionEndpoint": {
-      "displayName": "URL of the execution client's Engine JSON-RPC APIs",
+      "displayName": "Local execution Engine RPC-JSON API URL",
       "cliConfigPrefix": "--ee-endpoint=",
       "defaultValue": "http://host.containers.internal:8551",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "URL of the execution client's Engine JSON-RPC APIs.",
       "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#ee-endpoint"
     },
     "maxPeerCount": {
-      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "displayName": "Max Peer Count",
       "cliConfigPrefix": "--p2p-peer-upper-bound=",
       "defaultValue": "74",
       "uiControl": {
         "type": "text"
       },
+      "infoDescription": "Set to lower number to use less bandwidth",
       "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#p2p-peer-upper-bound"
     }
   },

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -17,10 +17,6 @@
       },
       "docker": {
         "containerVolumePath": "/var/lib/teku",
-        "ports": {
-          "p2p": ["9000"],
-          "rest": "5051"
-        },
         "raw": " --user 0",
         "forcedRawNodeInput": "--data-path=\"/var/lib/teku\" --ee-jwt-secret-file=\"/var/lib/teku/jwtsecret\""
       }
@@ -65,6 +61,16 @@
       "uiControl": {
         "type": "text"
       }
+    },
+    "p2pPorts": {
+      "displayName": "P2P listening port (UDP and TCP)",
+      "cliConfigPrefix": "--p2p-port=",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Example value: 9000",
+      "defaultValue": "9000",
+      "documentation": "https://docs.teku.consensys.net/reference/cli#p2p-port"
     },
     "http": {
       "displayName": "rpc http connections (*NiceNode requires http connections)",

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -63,7 +63,7 @@
       }
     },
     "p2pPorts": {
-      "displayName": "P2P listening port (UDP and TCP)",
+      "displayName": "P2P port (UDP and TCP)",
       "cliConfigPrefix": "--p2p-port=",
       "uiControl": {
         "type": "text"

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -9,7 +9,7 @@
     "input": {
       "defaultConfig": {
         "http": "Enabled",
-        "httpPort": "5052",
+        "httpPort": "5051",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "http://host.containers.internal:8551",
@@ -17,7 +17,11 @@
       },
       "docker": {
         "containerVolumePath": "/var/lib/teku",
-        "raw": "-p 9000:9000/tcp -p 9000:9000/udp -p 5052:5052 --user 0",
+        "ports": {
+          "p2p": ["9000"],
+          "rest": "5051"
+        },
+        "raw": " --user 0",
         "forcedRawNodeInput": "--data-path=\"/var/lib/teku\" --ee-jwt-secret-file=\"/var/lib/teku/jwtsecret\""
       }
     }
@@ -84,7 +88,7 @@
     "httpPort": {
       "displayName": "Specifies REST API listening port (HTTP).",
       "cliConfigPrefix": "--rest-api-port=",
-      "defaultValue": "5052",
+      "defaultValue": "5051",
       "uiControl": {
         "type": "text"
       },

--- a/src/common/nodeConfig.ts
+++ b/src/common/nodeConfig.ts
@@ -27,6 +27,7 @@ export type ConfigTranslation = {
   uiControl: ConfigTranslationControl;
   category?: string;
   cliConfigPrefix?: string;
+  secondaryCliConfigPrefix?: string;
   valuesJoinStr?: string;
   valuesWrapChar?: string;
   defaultValue?: ConfigValue;

--- a/src/common/nodeConfig.ts
+++ b/src/common/nodeConfig.ts
@@ -26,8 +26,7 @@ export type ConfigTranslation = {
   displayName: string;
   uiControl: ConfigTranslationControl;
   category?: string;
-  cliConfigPrefix?: string;
-  secondaryCliConfigPrefix?: string;
+  cliConfigPrefix?: string | string[];
   valuesJoinStr?: string;
   valuesWrapChar?: string;
   defaultValue?: ConfigValue;
@@ -90,7 +89,12 @@ export const buildCliConfig = ({
       if (configTranslation && configValue) {
         let currCliString = '';
         if (configTranslation.cliConfigPrefix) {
-          currCliString = configTranslation.cliConfigPrefix;
+          if (typeof configTranslation.cliConfigPrefix === 'string') {
+            currCliString = configTranslation.cliConfigPrefix;
+          } else if (Array.isArray(configTranslation.cliConfigPrefix)) {
+            const [firstCliConfigPrefix] = configTranslation.cliConfigPrefix;
+            currCliString = firstCliConfigPrefix;
+          }
         }
         if (configTranslation.uiControl.type === 'select/multiple') {
           const joinStr = configTranslation.valuesJoinStr ?? ',';
@@ -131,8 +135,13 @@ export const buildCliConfig = ({
           );
         }
 
-        if (configTranslation.secondaryCliConfigPrefix) {
-          currCliString += ` ${configTranslation.secondaryCliConfigPrefix}${configValue}`;
+        if (
+          configTranslation.cliConfigPrefix &&
+          Array.isArray(configTranslation.cliConfigPrefix)
+        ) {
+          for (let i = 1; i < configTranslation.cliConfigPrefix.length; i++) {
+            currCliString += ` ${configTranslation.cliConfigPrefix[i]}${configValue}`;
+          }
         }
 
         console.log(

--- a/src/common/nodeConfig.ts
+++ b/src/common/nodeConfig.ts
@@ -131,6 +131,10 @@ export const buildCliConfig = ({
           );
         }
 
+        if (configTranslation.secondaryCliConfigPrefix) {
+          currCliString += ` ${configTranslation.secondaryCliConfigPrefix}${configValue}`;
+        }
+
         console.log(
           'cliString, currCliString: ',
           JSON.stringify(cliString),

--- a/src/common/nodeSpec.ts
+++ b/src/common/nodeSpec.ts
@@ -36,12 +36,6 @@ export type DockerExecution = BaseNodeExecution & {
     default?: string[];
     docker?: {
       containerVolumePath: string;
-      ports: {
-        p2p: string[];
-        rest: string;
-        ws?: string;
-        engine?: string;
-      };
       raw?: string;
       forcedRawNodeInput?: string;
     };

--- a/src/common/nodeSpec.ts
+++ b/src/common/nodeSpec.ts
@@ -36,6 +36,12 @@ export type DockerExecution = BaseNodeExecution & {
     default?: string[];
     docker?: {
       containerVolumePath: string;
+      ports: {
+        p2p: string[];
+        rest: string;
+        ws?: string;
+        engine?: string;
+      };
       raw?: string;
       forcedRawNodeInput?: string;
     };

--- a/src/main/consts/notifications.ts
+++ b/src/main/consts/notifications.ts
@@ -67,9 +67,16 @@ export const NOTIFICATIONS = Object.freeze({
       status: STATUS.WARNING,
       limit: TIME.HOUR,
     },
-    PORT_CLOSED: {
+    P2P_PORTS_CLOSED: {
       title: 'Closed Ports',
       description: 'Ports {variable} may not be open on your local network',
+      status: STATUS.WARNING,
+      limit: 0,
+    },
+    UNEXPECTED_PORTS_OPEN: {
+      title: 'Unexpected Ports Open',
+      description:
+        'Ports {variable} are open and should be closed on your local network',
       status: STATUS.WARNING,
       limit: 0,
     },

--- a/src/main/consts/notifications.ts
+++ b/src/main/consts/notifications.ts
@@ -4,6 +4,8 @@ export const TIME = Object.freeze({
   HOUR: 3600000,
   DAY: 86400000,
   WEEK: 604800000,
+  MONTH: 2592000000,
+  YEAR: 31536000000,
 });
 
 const enum STATUS {
@@ -64,6 +66,12 @@ export const NOTIFICATIONS = Object.freeze({
       description: 'All nodes affected',
       status: STATUS.WARNING,
       limit: TIME.HOUR,
+    },
+    PORT_CLOSED: {
+      title: 'Closed Ports',
+      description: 'Ports {variable} may not be open on your local network',
+      status: STATUS.WARNING,
+      limit: 0,
     },
   },
 });

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,6 +23,7 @@ import {
   sendNodeLogs,
   stopSendingNodeLogs,
   getNodeStartCommand,
+  resetNodeConfig,
 } from './nodeManager';
 import { getNodes, getUserNodes, updateNodeProperties } from './state/nodes';
 import Node, { NodeId } from '../common/node';
@@ -147,6 +148,9 @@ export const initialize = () => {
   });
   ipcMain.handle('deleteNodeStorage', (_event, nodeId: NodeId) => {
     return deleteNodeStorage(nodeId);
+  });
+  ipcMain.handle('resetNodeConfig', (_event, nodeId: NodeId) => {
+    return resetNodeConfig(nodeId);
   });
   ipcMain.handle('sendNodeLogs', (_event, nodeId: NodeId) => {
     return sendNodeLogs(nodeId);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -57,6 +57,7 @@ import {
   markAllAsRead,
 } from './state/notifications';
 import { getFailSystemRequirements } from './minSystemRequirement';
+import { checkPorts } from './ports';
 
 // eslint-disable-next-line import/prefer-default-export
 export const initialize = () => {
@@ -203,4 +204,9 @@ export const initialize = () => {
   });
   ipcMain.handle('removeNotifications', removeNotifications);
   ipcMain.handle('markAllAsRead', markAllAsRead);
+
+  // Ports
+  ipcMain.handle('checkPorts', (_event, ports: number[]) => {
+    return checkPorts(ports);
+  });
 };

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -16,6 +16,7 @@ import { checkForUpdates } from './updater';
 import uninstallPodman from './podman/uninstall/uninstall';
 import nuclearUninstall from './nuclearUninstall';
 import { getFailSystemRequirements } from './minSystemRequirement';
+import { checkNodePortsAndNotify } from './ports';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
@@ -197,6 +198,13 @@ export default class MenuBuilder {
           label: 'Show Alpha Modal',
           click() {
             getSetHasSeenAlphaModal(false);
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Check Ports',
+          click() {
+            checkNodePortsAndNotify();
           },
         },
         { type: 'separator' },

--- a/src/main/monitor.ts
+++ b/src/main/monitor.ts
@@ -6,6 +6,7 @@ import logger from './logger';
 import * as storeNodes from './state/nodes';
 import { addNotification } from './state/notifications';
 import { NOTIFICATIONS } from './consts/notifications';
+import { checkPorts } from './ports';
 
 const watchProcessPollingInterval = 300000;
 let monitoringInterval: ReturnType<typeof setTimeout>;

--- a/src/main/monitor.ts
+++ b/src/main/monitor.ts
@@ -6,7 +6,7 @@ import logger from './logger';
 import * as storeNodes from './state/nodes';
 import { addNotification } from './state/notifications';
 import { NOTIFICATIONS } from './consts/notifications';
-import { checkPorts, getPodmanPorts } from './ports';
+import { getPodmanPorts } from './ports';
 
 const watchProcessPollingInterval = 300000;
 let monitoringInterval: ReturnType<typeof setTimeout>;

--- a/src/main/monitor.ts
+++ b/src/main/monitor.ts
@@ -6,7 +6,6 @@ import logger from './logger';
 import * as storeNodes from './state/nodes';
 import { addNotification } from './state/notifications';
 import { NOTIFICATIONS } from './consts/notifications';
-import { getPodmanPorts } from './ports';
 
 const watchProcessPollingInterval = 300000;
 let monitoringInterval: ReturnType<typeof setTimeout>;
@@ -31,7 +30,6 @@ export const getSystemTotalMemory = async (): Promise<number> => {
 // returns a list of warnings
 export const checkSystemHardware = async () => {
   const warnings = [];
-  console.log(`getPodmanPorts ${getPodmanPorts()}`);
   // Is total RAM < 8 GB?
   const totalMemoryGB = await getSystemTotalMemory();
   if (totalMemoryGB < 8) {

--- a/src/main/monitor.ts
+++ b/src/main/monitor.ts
@@ -6,7 +6,7 @@ import logger from './logger';
 import * as storeNodes from './state/nodes';
 import { addNotification } from './state/notifications';
 import { NOTIFICATIONS } from './consts/notifications';
-import { checkPorts } from './ports';
+import { checkPorts, getPodmanPorts } from './ports';
 
 const watchProcessPollingInterval = 300000;
 let monitoringInterval: ReturnType<typeof setTimeout>;
@@ -31,6 +31,9 @@ export const getSystemTotalMemory = async (): Promise<number> => {
 // returns a list of warnings
 export const checkSystemHardware = async () => {
   const warnings = [];
+  console.log(`getPodmanPorts ${getPodmanPorts()}`);
+  const ports = await checkPorts(getPodmanPorts());
+  console.log('checkPorts', ports);
   // Is total RAM < 8 GB?
   const totalMemoryGB = await getSystemTotalMemory();
   if (totalMemoryGB < 8) {

--- a/src/main/monitor.ts
+++ b/src/main/monitor.ts
@@ -32,8 +32,6 @@ export const getSystemTotalMemory = async (): Promise<number> => {
 export const checkSystemHardware = async () => {
   const warnings = [];
   console.log(`getPodmanPorts ${getPodmanPorts()}`);
-  const ports = await checkPorts(getPodmanPorts());
-  console.log('checkPorts', ports);
   // Is total RAM < 8 GB?
   const totalMemoryGB = await getSystemTotalMemory();
   if (totalMemoryGB < 8) {

--- a/src/main/nodeManager.ts
+++ b/src/main/nodeManager.ts
@@ -24,7 +24,7 @@ import { deleteDisk, getNodesDirPath, makeNodeDir } from './files';
 import { initialize as initNodeLibrary } from './nodeLibraryManager';
 import { ConfigValuesMap } from '../common/nodeConfig';
 import { checkNodePortsAndNotify } from './ports';
-import { getSetHasPortChanged } from './state/settings';
+import { getSetPortHasChanged } from './state/nodes';
 
 export const addNode = async (
   nodeSpec: NodeSpecification,
@@ -104,10 +104,9 @@ export const startNode = async (nodeId: NodeId) => {
       const containerIds = await startPodmanNode(dockerNode);
       dockerNode.runtime.processIds = containerIds;
       dockerNode.status = NodeStatus.running;
-      // if (getSetHasPortChanged()) {
-      checkNodePortsAndNotify(dockerNode);
-      // getSetHasPortChanged(false);
-      // }
+      if (getSetPortHasChanged(dockerNode)) {
+        checkNodePortsAndNotify(dockerNode);
+      }
       nodeStore.updateNode(dockerNode);
     }
   } catch (err) {

--- a/src/main/nodeManager.ts
+++ b/src/main/nodeManager.ts
@@ -60,7 +60,7 @@ export const addNode = async (
     if (runningNode?.status === NodeStatus.running) {
       checkNodePortsAndNotify(runningNode);
     }
-  }, 600000);
+  }, 600000); // 10 minutes
   return node;
 };
 

--- a/src/main/podman/podman.ts
+++ b/src/main/podman/podman.ts
@@ -395,7 +395,7 @@ const createPodmanPortInput = (
     return '';
   }
   const { p2p, rest, ws, engine } = ports;
-  const { httpPort } = configValuesMap || {};
+  const { httpPort, webSocketsPort } = configValuesMap || {};
   const result = [];
 
   // Handle p2p ports
@@ -416,8 +416,9 @@ const createPodmanPortInput = (
   }
 
   // Handle ws port if it exists
-  if (ws) {
-    result.push(`-p ${ws}:${ws}`);
+  const wsPort = webSocketsPort || ws;
+  if (wsPort) {
+    result.push(`-p ${wsPort}:${wsPort}`);
   }
 
   // Handle engine port if it exists

--- a/src/main/podman/podman.ts
+++ b/src/main/podman/podman.ts
@@ -4,7 +4,11 @@ import logger from '../logger';
 import Node, { NodeStatus } from '../../common/node';
 import { DockerExecution as PodmanExecution } from '../../common/nodeSpec';
 import { setDockerNodeStatus as setPodmanNodeStatus } from '../state/nodes';
-import { ConfigValuesMap, buildCliConfig } from '../../common/nodeConfig';
+import {
+  ConfigTranslationMap,
+  ConfigValuesMap,
+  buildCliConfig,
+} from '../../common/nodeConfig';
 import { send } from '../messenger';
 import * as metricsPolling from './metricsPolling';
 import { killChildProcess } from '../processExit';
@@ -381,56 +385,73 @@ export const removePodmanNode = async (node: Node) => {
 };
 
 const createPodmanPortInput = (
-  ports:
-    | {
-        p2p?: string[] | undefined;
-        rest?: string | undefined;
-        ws?: string | undefined;
-        engine?: string | undefined;
-      }
-    | undefined,
+  configTranslation: ConfigTranslationMap,
   configValuesMap?: ConfigValuesMap,
 ) => {
-  if (!ports) {
-    return '';
-  }
-  const { p2p, rest, ws, engine } = ports;
-  const { httpPort, webSocketsPort } = configValuesMap || {};
+  const {
+    p2pPorts,
+    p2pPortsUdp,
+    p2pPortsTcp,
+    enginePort,
+    httpPort,
+    webSocketsPort,
+  } = configTranslation;
+  const {
+    p2pPorts: configP2pPorts,
+    p2pPortsUdp: configP2pPortsUdp,
+    p2pPortsTcp: configP2pPortsTcp,
+    enginePort: configEnginePort,
+    httpPort: configHttpPort,
+    webSocketsPort: configWsPort,
+  } = configValuesMap || {};
   const result = [];
 
   // Handle p2p ports
-  if (p2p && Array.isArray(p2p)) {
-    if (p2p.length === 1) {
-      result.push(`-p ${p2p[0]}:${p2p[0]}/tcp`);
-      result.push(`-p ${p2p[0]}:${p2p[0]}/udp`);
-    } else if (p2p.length === 2) {
-      result.push(`-p ${p2p[0]}:${p2p[0]}`);
-      result.push(`-p ${p2p[1]}:${p2p[1]}/udp`);
+  if (configP2pPortsUdp || p2pPortsUdp || configP2pPortsTcp || p2pPortsTcp) {
+    const p2pUdpValue =
+      configP2pPortsUdp || (p2pPortsUdp && p2pPortsUdp.defaultValue);
+    const p2pTcpValue =
+      configP2pPortsTcp || (p2pPortsTcp && p2pPortsTcp.defaultValue);
+
+    if (p2pTcpValue) {
+      result.push(`-p ${p2pTcpValue}:${p2pTcpValue}/tcp`);
+    }
+    if (p2pUdpValue) {
+      result.push(`-p ${p2pUdpValue}:${p2pUdpValue}/udp`);
+    }
+  } else if (configP2pPorts || p2pPorts) {
+    const p2pValue = configP2pPorts || (p2pPorts && p2pPorts.defaultValue);
+    if (p2pValue) {
+      result.push(`-p ${p2pValue}:${p2pValue}/tcp`);
+      result.push(`-p ${p2pValue}:${p2pValue}/udp`);
     }
   }
 
-  // Handle rest port
-  const restPort = httpPort || rest;
-  if (restPort) {
-    result.push(`-p ${restPort}:${restPort}`);
+  // Handle http port
+  const restPortValue = configHttpPort || (httpPort && httpPort.defaultValue);
+  if (restPortValue) {
+    result.push(`-p ${restPortValue}:${restPortValue}`);
   }
 
   // Handle ws port if it exists
-  const wsPort = webSocketsPort || ws;
-  if (wsPort) {
-    result.push(`-p ${wsPort}:${wsPort}`);
+  const wsPortValue =
+    configWsPort || (webSocketsPort && webSocketsPort.defaultValue);
+  if (wsPortValue) {
+    result.push(`-p ${wsPortValue}:${wsPortValue}`);
   }
 
   // Handle engine port if it exists
-  if (engine) {
-    result.push(`-p ${engine}:${engine}`);
+  const enginePortValue =
+    configEnginePort || (enginePort && enginePort.defaultValue);
+  if (enginePortValue) {
+    result.push(`-p ${enginePortValue}:${enginePortValue}`);
   }
 
   return result.join(' ');
 };
 
 export const createRunCommand = (node: Node): string => {
-  const { specId, execution } = node.spec;
+  const { specId, execution, configTranslation } = node.spec;
   const { imageName, input } = execution as PodmanExecution;
   // try catch? .. podman dameon might need to be restarted if a bad gateway error occurs
 
@@ -438,10 +459,12 @@ export const createRunCommand = (node: Node): string => {
   let podmanVolumePath = '';
   let finalPodmanInput = '';
   if (input?.docker) {
-    podmanPortInput = createPodmanPortInput(
-      input.docker.ports,
-      node.config.configValuesMap,
-    );
+    if (configTranslation) {
+      podmanPortInput = createPodmanPortInput(
+        configTranslation,
+        node.config.configValuesMap,
+      );
+    }
     podmanVolumePath = input.docker.containerVolumePath;
     finalPodmanInput = podmanPortInput + (input?.docker.raw ?? '');
     if (podmanVolumePath) {

--- a/src/main/ports.ts
+++ b/src/main/ports.ts
@@ -1,7 +1,7 @@
 import { ConfigValue } from 'common/nodeConfig';
 import Node, { NodeConfig } from '../common/node';
 import { httpGet } from './httpReq';
-import { getNodes } from './state/nodes';
+import { getNodes, getSetPortHasChanged } from './state/nodes';
 import { addNotification } from './state/notifications';
 import { NOTIFICATIONS } from './consts/notifications';
 
@@ -130,8 +130,8 @@ export const checkPorts = async (
   });
 };
 
-export const checkNodePortsAndNotify = (node: Node) => {
-  const podmanPorts = getPodmanPortsForNode(node);
+export const checkNodePortsAndNotify = (node?: Node) => {
+  const podmanPorts = node ? getPodmanPortsForNode(node) : getPodmanPorts();
   checkPorts(podmanPorts)
     .then((openPorts) => {
       const closedPorts = getClosedPorts(podmanPorts, openPorts);
@@ -140,6 +140,9 @@ export const checkNodePortsAndNotify = (node: Node) => {
           NOTIFICATIONS.WARNING.PORT_CLOSED,
           closedPorts.join(', '),
         );
+      }
+      if (node) {
+        getSetPortHasChanged(node, false);
       }
       return null;
     })

--- a/src/main/ports.ts
+++ b/src/main/ports.ts
@@ -1,7 +1,9 @@
 import { ConfigValue } from 'common/nodeConfig';
-import Node, { NodeConfig } from 'common/node';
+import Node, { NodeConfig } from '../common/node';
 import { httpGet } from './httpReq';
 import { getNodes } from './state/nodes';
+import { addNotification } from './state/notifications';
+import { NOTIFICATIONS } from './consts/notifications';
 
 export const getPodmanPortsForNode = (node: Node): ConfigValue[] => {
   const portsArray = [] as ConfigValue[];
@@ -126,4 +128,22 @@ export const checkPorts = async (
       }
     });
   });
+};
+
+export const checkNodePortsAndNotify = (node: Node) => {
+  const podmanPorts = getPodmanPortsForNode(node);
+  checkPorts(podmanPorts)
+    .then((openPorts) => {
+      const closedPorts = getClosedPorts(podmanPorts, openPorts);
+      if (closedPorts.length > 0) {
+        addNotification(
+          NOTIFICATIONS.WARNING.PORT_CLOSED,
+          closedPorts.join(', '),
+        );
+      }
+      return null;
+    })
+    .catch((error) => {
+      console.log('Error checking ports:', error.message);
+    });
 };

--- a/src/main/ports.ts
+++ b/src/main/ports.ts
@@ -1,6 +1,30 @@
+import { execSync } from 'child_process';
 import { httpGet } from './httpReq';
 
-export const getUsedPorts = async () => {};
+export const getPodmanPorts = () => {
+  const output = execSync("podman ps -a --format '{{.Ports}}'", {
+    encoding: 'utf8',
+  });
+
+  // Split the output by lines and map through them to extract ports
+  return output
+    .split('\n')
+    .map((line) =>
+      (line.match(/\d+\.\d+\.\d+\.\d+:(\d+-?\d+)?->\d+/g) || []).flatMap(
+        (match) => {
+          const portSegment = match.split('->')[0].split(':')[1];
+          if (portSegment.includes('-')) {
+            const [start, end] = portSegment.split('-').map(Number);
+            return Array.from({ length: end - start + 1 }, (_, i) => i + start);
+          }
+          return [Number(portSegment)];
+        },
+      ),
+    )
+    .reduce((acc, currPorts) => acc.concat(currPorts), [])
+    .filter((port, index, self) => self.indexOf(port) === index); // Filter to get unique ports
+};
+
 /**
  * Checks the ports to see if they are open or closed
  * @param ports

--- a/src/main/ports.ts
+++ b/src/main/ports.ts
@@ -1,0 +1,31 @@
+import { httpGet } from './httpReq';
+
+export const getUsedPorts = async () => {};
+/**
+ * Checks the ports to see if they are open or closed
+ * @param ports
+ * @returns path of the downloaded file
+ */
+export const checkPorts = async (ports: number[]): Promise<any> => {
+  const baseUrl = 'https://port-checker.vercel.app/api/checker';
+  const url = `${baseUrl}?ports=${ports.join(',')}`;
+
+  const response = await httpGet(url);
+
+  return new Promise((resolve, reject) => {
+    let data = '';
+
+    response.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    response.on('end', () => {
+      if (response.statusCode !== 200) {
+        reject(new Error(`Request failed with status: ${response.statusCode}`));
+      } else {
+        const parsedData = JSON.parse(data);
+        resolve(parsedData?.open_ports);
+      }
+    });
+  });
+};

--- a/src/main/ports.ts
+++ b/src/main/ports.ts
@@ -1,4 +1,4 @@
-import { ConfigTranslationMap, ConfigValue } from 'common/nodeConfig';
+import { ConfigValue } from 'common/nodeConfig';
 import { httpGet } from './httpReq';
 import { getNodes } from './state/nodes';
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -89,6 +89,8 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.invoke('openDialogForStorageLocation'),
   deleteNodeStorage: (nodeId: NodeId) =>
     ipcRenderer.invoke('deleteNodeStorage', nodeId),
+  resetNodeConfig: (nodeId: NodeId) =>
+    ipcRenderer.invoke('resetNodeConfig', nodeId),
   sendNodeLogs: (nodeId: NodeId) => {
     ipcRenderer.invoke('sendNodeLogs', nodeId);
   },

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -138,4 +138,9 @@ contextBridge.exposeInMainWorld('electron', {
   },
   removeNotifications: () => ipcRenderer.invoke('removeNotifications'),
   markAllAsRead: () => ipcRenderer.invoke('markAllAsRead'),
+
+  // Ports
+  checkPorts: (ports: number[]) => {
+    ipcRenderer.invoke('checkPorts', ports);
+  },
 });

--- a/src/main/state/nodes.ts
+++ b/src/main/state/nodes.ts
@@ -1,4 +1,4 @@
-import { didPortsChange } from '../ports';
+import { checkNodePortsAndNotify, didPortsChange } from '../ports';
 import { send } from '../messenger';
 import Node, {
   isDockerNode,
@@ -95,7 +95,7 @@ export const updateNodeProperties = (
     propertiesToUpdate,
   );
   if (didPortsChange(propertiesToUpdate.config, node)) {
-    console.log('PORTS CHANGED');
+    // getSetHasPortChanged(true);
   }
   store.set(`${USER_NODES_KEY}.${NODES_KEY}.${node.id}`, newNode);
   return getNode(node.id);
@@ -150,6 +150,17 @@ export const setDockerNodeStatus = (
   // search all contianerIds for matching one
   store.set(`${USER_NODES_KEY}.${NODES_KEY}.${nodeToUpdate.id}.status`, status);
   return getNode(nodeToUpdate.id);
+};
+
+export const getSetHasPortChanged = (hasPortChanged?: boolean) => {
+  // if (hasPortChanged !== undefined) {
+  //   logger.info(`Setting hasPortChanged to ${hasPortChanged}`);
+  //   store.set(`${SETTINGS_KEY}.${APP_HAS_PORT_CHANGED}`, hasPortChanged);
+  // }
+  // const hasPortChangedValue: boolean = store.get(
+  //   `${SETTINGS_KEY}.${APP_HAS_PORT_CHANGED}`,
+  // );
+  // return hasPortChangedValue;
 };
 
 // todo: an optimization

--- a/src/main/state/nodes.ts
+++ b/src/main/state/nodes.ts
@@ -1,4 +1,4 @@
-import { checkNodePortsAndNotify, didPortsChange } from '../ports';
+import { didPortsChange } from '../ports';
 import { send } from '../messenger';
 import Node, {
   isDockerNode,

--- a/src/main/state/nodes.ts
+++ b/src/main/state/nodes.ts
@@ -79,6 +79,22 @@ export const addNode = (newNode: Node) => {
   return newNode;
 };
 
+export const getSetPortHasChanged = (
+  node: Node,
+  portHasChanged?: boolean | undefined,
+) => {
+  if (portHasChanged !== undefined) {
+    store.set(
+      `${USER_NODES_KEY}.${NODES_KEY}.${node.id}.portHasChanged`,
+      portHasChanged,
+    );
+  }
+  const portHasChangedValue: boolean = store.get(
+    `${USER_NODES_KEY}.${NODES_KEY}.${node.id}.portHasChanged`,
+  );
+  return portHasChangedValue;
+};
+
 export const updateNodeProperties = (
   nodeId: NodeId,
   propertiesToUpdate: any,
@@ -94,10 +110,10 @@ export const updateNodeProperties = (
     newNode,
     propertiesToUpdate,
   );
-  if (didPortsChange(propertiesToUpdate.config, node)) {
-    // getSetHasPortChanged(true);
-  }
   store.set(`${USER_NODES_KEY}.${NODES_KEY}.${node.id}`, newNode);
+  if (didPortsChange(propertiesToUpdate.config, node)) {
+    getSetPortHasChanged(newNode, true);
+  }
   return getNode(node.id);
 };
 
@@ -150,17 +166,6 @@ export const setDockerNodeStatus = (
   // search all contianerIds for matching one
   store.set(`${USER_NODES_KEY}.${NODES_KEY}.${nodeToUpdate.id}.status`, status);
   return getNode(nodeToUpdate.id);
-};
-
-export const getSetHasPortChanged = (hasPortChanged?: boolean) => {
-  // if (hasPortChanged !== undefined) {
-  //   logger.info(`Setting hasPortChanged to ${hasPortChanged}`);
-  //   store.set(`${SETTINGS_KEY}.${APP_HAS_PORT_CHANGED}`, hasPortChanged);
-  // }
-  // const hasPortChangedValue: boolean = store.get(
-  //   `${SETTINGS_KEY}.${APP_HAS_PORT_CHANGED}`,
-  // );
-  // return hasPortChangedValue;
 };
 
 // todo: an optimization

--- a/src/main/state/nodes.ts
+++ b/src/main/state/nodes.ts
@@ -1,3 +1,4 @@
+import { didPortsChange } from '../ports';
 import { send } from '../messenger';
 import Node, {
   isDockerNode,
@@ -93,6 +94,9 @@ export const updateNodeProperties = (
     newNode,
     propertiesToUpdate,
   );
+  if (didPortsChange(propertiesToUpdate.config, node)) {
+    console.log('PORTS CHANGED');
+  }
   store.set(`${USER_NODES_KEY}.${NODES_KEY}.${node.id}`, newNode);
   return getNode(node.id);
 };

--- a/src/main/state/notifications.ts
+++ b/src/main/state/notifications.ts
@@ -67,11 +67,28 @@ const checkIfNotificationCanBeAdded = (
   );
 };
 
+const interpolate = (str: string, variable: string) => {
+  // For this example, we're handling a specific format: {variable}
+  if (str.includes('{variable}')) {
+    return str.replace('{variable}', variable);
+  }
+  return str;
+};
+
 // TODO: add variable support for language string keys
-export const addNotification = (notificationObject: NotificationProps) => {
+export const addNotification = (
+  notificationObject: NotificationProps,
+  variable?: string,
+) => {
   const notifications = store.get(NOTIFICATIONS_KEY) || [];
+  // eslint-disable-next-line prefer-const
+  let { title, description, status } = notificationObject;
+
+  if (variable) {
+    description = interpolate(description, variable);
+  }
+
   if (checkIfNotificationCanBeAdded(notifications, notificationObject)) {
-    const { title, description, status } = notificationObject;
     const newNotification = {
       title,
       description,

--- a/src/renderer/Generics/redesign/Header/Header.tsx
+++ b/src/renderer/Generics/redesign/Header/Header.tsx
@@ -8,7 +8,6 @@ import { NodeIcon } from '../NodeIcon/NodeIcon';
 import { UpdateCallout } from '../UpdateCallout/UpdateCallout';
 import { Menu } from '../Menu/Menu';
 import { MenuItem } from '../MenuItem/MenuItem';
-import { HorizontalLine } from '../HorizontalLine/HorizontalLine';
 import {
   container,
   iconContainer,
@@ -142,13 +141,7 @@ export const Header = (props: NodeOverviewProps) => {
             size="small"
             onClick={() => {
               if (screenType === 'client') {
-                dispatch(
-                  setModalState({
-                    isModalOpen: true,
-                    screen: { route: 'nodeSettings', type: 'modal' },
-                  }),
-                );
-                // setIsSettingsDisplayed(!isSettingsDisplayed);
+                setIsSettingsDisplayed(!isSettingsDisplayed);
               } else {
                 console.log('open preferences!');
               }
@@ -160,18 +153,28 @@ export const Header = (props: NodeOverviewProps) => {
             <div className={popupContainer} tabIndex={0}>
               <Menu width={156}>
                 <MenuItem
-                  text="Restart Client"
+                  text="Node Settings"
                   onClick={() => {
-                    console.log('Restart Client');
+                    dispatch(
+                      setModalState({
+                        isModalOpen: true,
+                        screen: { route: 'nodeSettings', type: 'modal' },
+                      }),
+                    );
                   }}
                 />
                 <MenuItem
-                  text="Check for Updates..."
+                  text="Remove Node"
                   onClick={() => {
-                    console.log('Check for Updates...');
+                    dispatch(
+                      setModalState({
+                        isModalOpen: true,
+                        screen: { route: 'removeNode', type: 'alert' },
+                      }),
+                    );
                   }}
                 />
-                <HorizontalLine type="menu" />
+                {/* <HorizontalLine type="menu" />
                 <MenuItem
                   text="Client Versions"
                   onClick={() => {
@@ -185,7 +188,7 @@ export const Header = (props: NodeOverviewProps) => {
                     console.log('Switch Client');
                   }}
                   disabled
-                />
+                /> */}
               </Menu>
             </div>
           )}

--- a/src/renderer/Generics/redesign/Header/header.css.ts
+++ b/src/renderer/Generics/redesign/Header/header.css.ts
@@ -77,11 +77,11 @@ export const buttonContainer = style({
 });
 
 export const menuButtonContainer = style({
-  // position: 'relative',
+  position: 'relative',
 });
 
 export const popupContainer = style({
   position: 'absolute',
-  right: 0,
   top: 32,
+  right: 0,
 });

--- a/src/renderer/Generics/redesign/HeaderButton/headerButton.css.ts
+++ b/src/renderer/Generics/redesign/HeaderButton/headerButton.css.ts
@@ -1,9 +1,10 @@
-import { style } from '@vanilla-extract/css';
+import { style, ComplexStyleRule } from '@vanilla-extract/css';
 import { vars } from '../theme.css';
 
 export const container = style({
   boxSizing: 'border-box',
   flex: 'none',
+  '-webkit-app-region': 'no-drag',
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
@@ -21,4 +22,4 @@ export const container = style({
   ':active': {
     backgroundColor: vars.components.headerButtonActive,
   },
-});
+} as ComplexStyleRule); // fix for lacking '-webkit-app-region' type

--- a/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
+++ b/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
@@ -50,7 +50,7 @@ const LabelSettingsSection = ({
           <div className={lineContainer} key={index}>
             <div className={labelAndDescriptionContainer}>
               <div className={lineKeyText}>{item.label}</div>
-              <Caption>
+              <Caption type={type}>
                 {item.description}{' '}
                 {item.learnMoreLink && (
                   <ExternalLink

--- a/src/renderer/Generics/redesign/LabelSetting/labelSettingsSection.css.ts
+++ b/src/renderer/Generics/redesign/LabelSetting/labelSettingsSection.css.ts
@@ -57,7 +57,7 @@ export const labelAndDescriptionContainer = style({
   flex: 'none',
   order: 0,
   flexGrow: 0,
-  maxWidth: '100%',
+  maxWidth: '68%',
 });
 
 export const lineKeyText = style({

--- a/src/renderer/Generics/redesign/Typography/Caption.tsx
+++ b/src/renderer/Generics/redesign/Typography/Caption.tsx
@@ -4,11 +4,14 @@ import { captionTextClass } from './caption.css';
 export interface CaptionProps {
   children?: React.ReactNode;
   text?: React.ReactNode | string;
+  type?: string;
   // todo: display block or inline?
 }
 
-const Caption = ({ text, children }: CaptionProps) => {
-  return <div className={captionTextClass}>{children ?? text}</div>;
+const Caption = ({ text, children, type }: CaptionProps) => {
+  return (
+    <div className={[captionTextClass, type].join(' ')}>{children ?? text}</div>
+  );
 };
 
 export default Caption;

--- a/src/renderer/Generics/redesign/Typography/caption.css.ts
+++ b/src/renderer/Generics/redesign/Typography/caption.css.ts
@@ -6,4 +6,9 @@ export const captionTextClass = style({
   fontSize: 11,
   lineHeight: '14px',
   color: vars.color.font70,
+  selectors: {
+    [`&.modal`]: {
+      color: vars.color.font50,
+    },
+  },
 });

--- a/src/renderer/Presentational/ModalManager/ModalManager.tsx
+++ b/src/renderer/Presentational/ModalManager/ModalManager.tsx
@@ -7,6 +7,7 @@ import { modalRoutes } from './modalUtils';
 import { NodeSettingsModal } from './NodeSettingsModal';
 import { PreferencesModal } from './PreferencesModal';
 import { RemoveNodeModal } from './RemoveNodeModal';
+import { ResetConfigModal } from './ResetConfigModal';
 import { AddNodeModal } from './AddNodeModal';
 import { AlphaBuildModal } from './AlphaBuildModal';
 import FailSystemRequirementsModal from './FailSystemRequirementsModal';
@@ -53,6 +54,8 @@ const ModalManager = () => {
       return null;
     case modalRoutes.removeNode:
       return <RemoveNodeModal modalOnClose={modalOnClose} />;
+    case modalRoutes.resetConfig:
+      return <ResetConfigModal modalOnClose={modalOnClose} />;
     case modalRoutes.updateUnavailable:
       return null;
     default:

--- a/src/renderer/Presentational/ModalManager/ResetConfigModal.tsx
+++ b/src/renderer/Presentational/ModalManager/ResetConfigModal.tsx
@@ -1,36 +1,47 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { setModalState } from '../../state/modal';
 import electron from '../../electronGlobal';
-import RemoveNodeWrapper from '../RemoveNodeModal/RemoveNodeWrapper';
+import { useAppDispatch } from '../../state/hooks';
 import { Modal } from '../../Generics/redesign/Modal/Modal';
 import { modalOnChangeConfig, ModalConfig } from './modalUtils';
+import ResetConfigWrapper from '../ResetConfigModal/ResetConfigWrapper';
 
 type Props = {
   modalOnClose: () => void;
 };
 
-export const RemoveNodeModal = ({ modalOnClose }: Props) => {
+export const ResetConfigModal = ({ modalOnClose }: Props) => {
   const [modalConfig, setModalConfig] = useState<ModalConfig>({});
-  const modalTitle = 'Are you sure you want to remove this node?';
-  const buttonSaveLabel = 'Remove node';
+  const dispatch = useAppDispatch();
+  const { t } = useTranslation();
+  const modalTitle = t('ResetNodeSettingsQuestion');
+  const buttonSaveLabel = t('ResetNodeSettingsModal');
   const buttonSaveType = 'danger';
 
   const modalOnSaveConfig = async (updatedConfig: ModalConfig | undefined) => {
-    const { selectedNode, isDeleteStorage = true } =
-      updatedConfig || (modalConfig as ModalConfig);
+    const { selectedNode } = updatedConfig || (modalConfig as ModalConfig);
 
     try {
       if (selectedNode) {
-        await electron.removeNode(selectedNode.id, {
-          isDeleteStorage,
-        });
+        electron.resetNodeConfig(selectedNode.id);
       }
     } catch (err) {
       console.error(err);
       throw new Error(
-        'There was an error removing the node. Try again and please report the error to the NiceNode team in Discord.',
+        'There was an error resetting config to default. Try again and please report the error to the NiceNode team in Discord.',
       );
     }
     modalOnClose();
+  };
+
+  const onCancel = () => {
+    dispatch(
+      setModalState({
+        isModalOpen: true,
+        screen: { route: 'nodeSettings', type: 'modal' },
+      }),
+    );
   };
 
   return (
@@ -41,9 +52,9 @@ export const RemoveNodeModal = ({ modalOnClose }: Props) => {
       buttonSaveType={buttonSaveType}
       modalOnSaveConfig={modalOnSaveConfig}
       modalOnClose={modalOnClose}
-      modalOnCancel={modalOnClose}
+      modalOnCancel={onCancel}
     >
-      <RemoveNodeWrapper
+      <ResetConfigWrapper
         modalOnChangeConfig={(config, save) => {
           modalOnChangeConfig(
             config,

--- a/src/renderer/Presentational/ModalManager/modalUtils.tsx
+++ b/src/renderer/Presentational/ModalManager/modalUtils.tsx
@@ -27,6 +27,7 @@ export const modalRoutes = Object.freeze({
   clientVersions: 'clientVersions',
   stopNode: 'stopNode',
   removeNode: 'removeNode',
+  resetConfig: 'resetConfig',
   updateUnavailable: 'updateUnavailable',
   failSystemRequirements: 'failSystemRequirements',
   alphaBuild: 'alphaBuild',

--- a/src/renderer/Presentational/NodeSettings/NodeSettings.tsx
+++ b/src/renderer/Presentational/NodeSettings/NodeSettings.tsx
@@ -23,7 +23,7 @@ export interface NodeSettingsProps {
   isWalletSettingsEnabled?: boolean;
   isDisabled?: boolean;
   onChange?: SettingChangeHandler;
-  onClickRemoveNode: () => void;
+  onClickResetConfig: () => void;
   nodeStartCommand?: string;
 }
 
@@ -34,7 +34,7 @@ const NodeSettings = ({
   isWalletSettingsEnabled,
   isDisabled,
   onChange,
-  onClickRemoveNode,
+  onClickResetConfig,
   nodeStartCommand,
 }: NodeSettingsProps) => {
   const { t: tNiceNode } = useTranslation();
@@ -81,11 +81,11 @@ const NodeSettings = ({
             </div>
           </>
         )}
-        {/* Remove Node link */}
+        {/* Reset to default config link */}
         <div style={{ padding: '16px 0px 16px 0px' }}>
           <InternalLink
-            text={tNiceNode('RemoveThisNode')}
-            onClick={onClickRemoveNode}
+            text="Reset to defaults"
+            onClick={onClickResetConfig}
             danger
           />
         </div>

--- a/src/renderer/Presentational/NodeSettings/NodeSettingsWrapper.tsx
+++ b/src/renderer/Presentational/NodeSettings/NodeSettingsWrapper.tsx
@@ -253,13 +253,15 @@ const NodeSettingsWrapper = ({
       isWalletSettingsEnabled={sIsWalletSettingsEnabled}
       isDisabled={sIsConfigDisabled}
       onChange={onNodeConfigChange}
-      onClickRemoveNode={() => {
-        dispatch(
-          setModalState({
-            isModalOpen: true,
-            screen: { route: 'removeNode', type: 'alert' },
-          }),
-        );
+      onClickResetConfig={() => {
+        if (selectedNode) {
+          dispatch(
+            setModalState({
+              isModalOpen: true,
+              screen: { route: 'resetConfig', type: 'alert' },
+            }),
+          );
+        }
       }}
       nodeStartCommand={sNodeStartCommand}
     />

--- a/src/renderer/Presentational/ResetConfigModal/ResetConfigWrapper.tsx
+++ b/src/renderer/Presentational/ResetConfigModal/ResetConfigWrapper.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { ModalConfig } from '../ModalManager/modalUtils';
+import { useAppSelector } from '../../state/hooks';
+import { selectSelectedNode } from '../../state/node';
+
+export interface ResetConfigWrapperProps {
+  modalOnChangeConfig: (config: ModalConfig, save?: boolean) => void;
+}
+
+const ResetConfigWrapper = ({
+  modalOnChangeConfig,
+}: ResetConfigWrapperProps) => {
+  const selectedNode = useAppSelector(selectSelectedNode);
+
+  useEffect(() => {
+    modalOnChangeConfig({ selectedNode });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedNode]);
+
+  return <></>;
+};
+
+export default ResetConfigWrapper;

--- a/src/renderer/__mocks__/custom-preload-mock.ts
+++ b/src/renderer/__mocks__/custom-preload-mock.ts
@@ -95,6 +95,7 @@ export const openDialogForStorageLocation = () => {};
 export const getNodesDefaultStorageLocation = () => '/user/storage/nodes/';
 export const updateNodeLastSyncedBlock = () => {};
 export const deleteNodeStorage = () => true;
+export const resetNodeConfig = () => {};
 export const sendNodeLogs = () => {};
 export const stopSendingNodeLogs = () => {};
 

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -96,6 +96,9 @@ declare global {
       addNotification(notification: any): void;
       removeNotifications(): void;
       markAllAsRead(): void;
+
+      // Ports
+      checkPorts(ports: number[]): void;
     };
 
     performance: Performance;

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -66,6 +66,7 @@ declare global {
       openDialogForStorageLocation(): CheckStorageDetails;
       updateNodeLastSyncedBlock(nodeId: NodeId, block: number): void;
       deleteNodeStorage(nodeId: NodeId): boolean;
+      resetNodeConfig(nodeId: NodeId): boolean;
       sendNodeLogs(nodeId: NodeId): void;
       stopSendingNodeLogs(nodeId?: NodeId): void;
 

--- a/src/stories/Presentational/Sidebar.stories.tsx
+++ b/src/stories/Presentational/Sidebar.stories.tsx
@@ -41,12 +41,6 @@ Primary.args = {
               },
               docker: {
                 containerVolumePath: '/var/lib/besu',
-                ports: {
-                  p2p: ['30303'],
-                  rest: '8545',
-                  ws: '8546',
-                  engine: '8551',
-                },
                 raw: ' --user 0',
                 forcedRawNodeInput: '--data-path="/var/lib/besu"',
               },
@@ -339,10 +333,6 @@ Primary.args = {
               },
               docker: {
                 containerVolumePath: '/home/user/nimbus-eth2/build/data',
-                ports: {
-                  p2p: ['9000'],
-                  rest: '5052',
-                },
                 raw: ' --user 0',
                 forcedRawNodeInput:
                   '--data-dir=build/data/shared_mainnet_0 --network=mainnet',

--- a/src/stories/Presentational/Sidebar.stories.tsx
+++ b/src/stories/Presentational/Sidebar.stories.tsx
@@ -41,7 +41,13 @@ Primary.args = {
               },
               docker: {
                 containerVolumePath: '/var/lib/besu',
-                raw: '-p 30303:30303/tcp -p 30303:30303/udp -p 8545:8545 -p 8546:8546',
+                ports: {
+                  p2p: ['30303'],
+                  rest: '8545',
+                  ws: '8546',
+                  engine: '8551',
+                },
+                raw: ' --user 0',
                 forcedRawNodeInput: '--data-path="/var/lib/besu"',
               },
             },
@@ -333,7 +339,11 @@ Primary.args = {
               },
               docker: {
                 containerVolumePath: '/home/user/nimbus-eth2/build/data',
-                raw: '-p 9000:9000/tcp -p 9000:9000/udp -p 5052:5052',
+                ports: {
+                  p2p: ['9000'],
+                  rest: '5052',
+                },
+                raw: ' --user 0',
                 forcedRawNodeInput:
                   '--data-dir=build/data/shared_mainnet_0 --network=mainnet',
               },


### PR DESCRIPTION
- moved some parts of config key titles to config key descriptions to make them shorter
- removed raw ports from configs, and added method to dynamically add ports to podman command based on config
- added support for multiple cli prefix, when config setting must apply to multiple cli params depending on node
- added port checking related methods and api
- added notification for closed ports (including string interpolation to pass variables into strings)
- fixed config styles in node settings modal