### PR TITLE
Feat/node settings in add node flow

### DIFF
--- a/src/common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json
+++ b/src/common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json
@@ -2,97 +2,68 @@
   "specId": "arbitrum",
   "version": "1.0.0",
   "displayName": "Arbitrum One",
+  "displayTagline": "Non-Validating Node",
   "execution": {
-    "executionTypes": ["docker"],
-    "defaultExecutionType": "docker",
-    "imageName": "docker.io/offchainlabs/arb-node:v1.4.0-f4bbe91",
-    "input": {
-      "defaultConfig": {
-        "eth1ProviderUrl": "http://host.containers.internal:8545",
-        "httpCorsDomains": "http://localhost"
-      },
-      "docker": {
-        "containerVolumePath": "/home/user/.arbitrum/mainnet",
-        "raw": "-p 8547:8547 -p 8548:8548 -p 9642:9642"
-      }
-    },
-    "dependencies": ["L1/ExecutionClient"]
+    "executionTypes": ["nodePackage"],
+    "defaultExecutionType": "nodePackage",
+    "services" : [{
+      "serviceId": "executionClient",
+      "name" : "Execution Client",
+      "nodeOptions": ["nitro"],
+      "required": true
+    }]
   },
+  "category": "Ethereum/L2",
   "rpcTranslation": "eth-l1",
-  "configTranslation": {
-    "eth1ProviderUrl": {
-      "displayName": "This should point to the HTTP RPC endpoint of your Ethereum entry-point (could be infura or other)",
-      "cliConfigPrefix": "--l1.url ",
-      "niceNodeDefaultValue": "http://host.containers.internal:8545",
-      "uiControl": {
-        "type": "text"
-      },
-      "infoDescription": "This should point to the HTTP RPC endpoint of your Ethereum entry-point, typically a local Ethereum client or a hosted gateway service such as Infura or Cloudflare. Examples: infura: https://goerli.infura.io/v3/<PROJECT_ID>, local EC (nethermind/besu/geth): http://localhost:8545"
+  "systemRequirements": {
+    "documentationUrl": "https://geth.arbitrum.org/docs/interface/hardware",
+    "cpu": {
+      "cores": 4
     },
-    "websockets": {
-      "displayName": "rpc websocket connections (*BeaconNodes may require websocket connections)",
+    "memory": {
+      "minSizeGBs": 8
+    },
+    "storage": {
+      "minSizeGBs": 1600,
+      "ssdRequired": true
+    },
+    "internet": {
+      "minDownloadSpeedMbps": 25,
+      "minUploadSpeedMbps": 10
+    },
+    "docker": {
+      "required": true
+    }
+  },
+  "configTranslation": {
+    "dataDir": {
+      "displayName": "Node data is stored in this folder",
+      "cliConfigPrefix": "--datadir ",
+      "defaultValue": "~/.ethereum",
+      "uiControl": {
+        "type": "filePath"
+      },
+      "infoDescription": "Data directory for the databases and keystore (default: \"~/.ethereum\")"
+    },
+    "network": {
+      "displayName": "mainnet or a testnet",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [
           {
-            "value": "Enabled",
-            "config": "--ws"
+            "value": "Mainnet",
+            "config": "--network mainnet"
           },
           {
-            "value": "Disabled"
+            "value": "Testnet",
+            "config": "--network testnet"
           }
         ]
       },
-      "defaultValue": "Disabled"
-    },
-    "httpApis": {
-      "displayName": "Enabled HTTP APIs",
-      "cliConfigPrefix": "--http.api ",
-      "defaultValue": "eth,net,web3",
-      "valuesJoinStr": ",",
-      "uiControl": {
-        "type": "select/multiple",
-        "controlTranslations": [
-          {
-            "value": "eth",
-            "config": "Eth"
-          },
-          {
-            "value": "net",
-            "config": "Net"
-          },
-          {
-            "value": "web3",
-            "config": "Web3"
-          },
-          {
-            "value": "debug",
-            "config": "Debug"
-          },
-
-          {
-            "value": "personal",
-            "config": "Personal"
-          },
-          {
-            "value": "admin",
-            "config": "Admin"
-          }
-        ]
-      }
-    },
-    "httpCorsDomains": {
-      "displayName": "Change where the node accepts http connections (use comma separated urls)",
-      "cliConfigPrefix": "--http.corsdomain ",
-      "uiControl": {
-        "type": "text"
-      }
+      "defaultValue": "Disabled",
+      "documentation": "https://geth.ethereum.org/docs/rpc/server"
     }
   },
-  "category": "L2/ArbitrumOne",
-  "documentation": {
-    "default": "https://arbitrum.io/",
-    "docker": "https://developer.offchainlabs.com/docs/running_node"
-  },
-  "iconUrl": "https://arbitrum.io/wp-content/uploads/2021/08/Arbitrum_Symbol-Full-color-White-background-937x1024.png"
+  "addNodeDescription": "Designed with you in mind, Arbitrum is the leading Layer 2 technology that empowers you to explore and build in the largest Layer 1 ecosystem, Ethereum.",
+  "description": "Designed with you in mind, Arbitrum is the leading Layer 2 technology that empowers you to explore and build in the largest Layer 1 ecosystem, Ethereum.  Take it to the next layer with Nitro. Making Ethereum more inclusive and sustainable, Nitro is the most advanced blockchain scaling technology in the industry."
 }

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -55,6 +55,33 @@
       },
       "documentation": "https://besu.hyperledger.org/public-networks/reference/cli/options#data-path"
     },
+    "network": {
+      "displayName": "Network (Besu)",
+      "cliConfigPrefix": "--network=",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "syncMode": {
       "displayName": "Node synchronization mode",
       "category": "Syncronization",

--- a/src/common/NodeSpecs/ethereum/ethereum-v1.0.0.json
+++ b/src/common/NodeSpecs/ethereum/ethereum-v1.0.0.json
@@ -2,7 +2,7 @@
   "specId": "ethereum",
   "version": "1.0.0",
   "displayName": "Ethereum",
-  "displayTagline": "Non-Validating Node - Ethereum mainnet",
+  "displayTagline": "Non-Validating Node - Ethereum",
   "execution": {
     "executionTypes": ["nodePackage"],
     "defaultExecutionType": "nodePackage",

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -70,6 +70,32 @@
       },
       "infoDescription": "Data directory for the databases and keystore (default: \"~/.ethereum\")"
     },
+    "network": {
+      "displayName": "Network (Geth)",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "--mainnet"
+          },
+          {
+            "value": "Holesky",
+            "config": "--holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "--goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "--sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "http": {
       "displayName": "RPC HTTP connections",
       "uiControl": {

--- a/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
+++ b/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
@@ -8,11 +8,16 @@
     "defaultExecutionType": "docker",
     "input": {
       "defaultConfig": {
+        "p2pPorts" : "2282",
+        "gRpcPort" : "2283",
+        "farcasterNetwork" : "1",
+        "boostrapNode": "/dns/nemes.farcaster.xyz/tcp/2282"
       },
       "docker": {
         "containerVolumePath": "/home/node/app/apps/hubble",
-        "raw": "",
-        "forcedRawNodeInput": "node --no-warnings build/cli.js start --ip 0.0.0.0"
+        "raw": " --user 0 -p 2281:2281",
+        "initNodeCommand" : "yarn identity create",
+        "forcedRawNodeInput": "node --no-warnings build/cli.js start --ip 0.0.0.0 "
       }
     },
     "imageName": "docker.io/farcasterxyz/hubble:latest"
@@ -39,7 +44,7 @@
     "ethMainnetRpcUrl": {
       "displayName": "Ethereum Mainnet RPC Endpoint (local node or provider)",
       "cliConfigPrefix": "--eth-mainnet-rpc-url ",
-      "defaultValue": "http://host.internal.containers:8545",
+      "defaultValue": "",
       "uiControl": {
         "type": "text"
       },
@@ -48,7 +53,7 @@
     "optimismMainnetRpcUrl": {
       "displayName": "Optimism Mainnet RPC Endpoint (local node or provider)",
       "cliConfigPrefix": "--l2-rpc-url ",
-      "defaultValue": "http://host.internal.containers:8547",
+      "defaultValue": "",
       "uiControl": {
         "type": "text"
       },
@@ -72,8 +77,8 @@
       "infoDescription": "Example value: 2282",
       "defaultValue": "2282"
     },
-    "httpPort": {
-      "displayName": "HTTP-RPC server listening port",
+    "gRpcPort": {
+      "displayName": "gRPC server listening port",
       "cliConfigPrefix": "--rpc-port ",
       "defaultValue": "2283",
       "uiControl": {

--- a/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
+++ b/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
@@ -37,22 +37,22 @@
   },
   "configTranslation": {
     "ethMainnetRpcUrl": {
-      "displayName": "Ethereum mainnet RPC URL (local node or alchemy/infura/etc.)",
+      "displayName": "Ethereum Mainnet RPC Endpoint (local node or provider)",
       "cliConfigPrefix": "--eth-mainnet-rpc-url ",
       "defaultValue": "http://host.internal.containers:8545",
       "uiControl": {
         "type": "text"
       },
-      "documentation": "https://www.thehubble.xyz/intro/install.html#install-via-docker"
+      "addNodeFlow": "required"
     },
     "optimismMainnetRpcUrl": {
-      "displayName": "Optimism mainnet RPC URL (local node or alchemy/infura/etc.)",
+      "displayName": "Optimism Mainnet RPC Endpoint (local node or provider)",
       "cliConfigPrefix": "--l2-rpc-url ",
       "defaultValue": "http://host.internal.containers:8547",
       "uiControl": {
         "type": "text"
       },
-      "documentation": "https://www.thehubble.xyz/intro/install.html#install-via-docker"
+      "addNodeFlow": "required"
     },
     "hubOperatorFid": {
       "displayName": "Set this to your Farcaster FID ",
@@ -60,6 +60,7 @@
       "uiControl": {
         "type": "text"
       },
+      "addNodeFlow": "advanced",
       "documentation": "https://www.thehubble.xyz/intro/install.html#install-via-docker"
     },
     "p2pPorts": {
@@ -96,6 +97,7 @@
       "uiControl": {
         "type": "text"
       },
+      "addNodeFlow": "advanced",
       "infoDescription": "Example value: 1"
     }
   },

--- a/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
+++ b/src/common/NodeSpecs/hubble/hubble-v1.0.0.json
@@ -9,13 +9,13 @@
     "input": {
       "defaultConfig": {
         "p2pPorts" : "2282",
-        "gRpcPort" : "2283",
+        "httpPort" : "2281",
         "farcasterNetwork" : "1",
         "boostrapNode": "/dns/nemes.farcaster.xyz/tcp/2282"
       },
       "docker": {
         "containerVolumePath": "/home/node/app/apps/hubble",
-        "raw": " --user 0 -p 2281:2281",
+        "raw": " --user 0",
         "initNodeCommand" : "yarn identity create",
         "forcedRawNodeInput": "node --no-warnings build/cli.js start --ip 0.0.0.0 "
       }
@@ -77,14 +77,14 @@
       "infoDescription": "Example value: 2282",
       "defaultValue": "2282"
     },
-    "gRpcPort": {
-      "displayName": "gRPC server listening port",
-      "cliConfigPrefix": "--rpc-port ",
-      "defaultValue": "2283",
+    "httpPort": {
+      "displayName": "HTTP-RPC server listening port",
+      "cliConfigPrefix": "--http-api-port ",
+      "defaultValue": "2281",
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Example value: 2283"
+      "infoDescription": "Example value: 2281"
     },
     "boostrapNode": {
       "displayName": "A Farcaster node to boostrap peer discovery",

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -12,12 +12,12 @@
         "httpCorsDomains": "http://localhost",
         "websockets": "Enabled",
         "executionEndpoint": "http://host.containers.internal:8551",
-        "checkpointSyncUrl": "https://mainnet.checkpoint.sigp.io"
+        "network": "Mainnet"
       },
       "docker": {
         "containerVolumePath": "/root/.lighthouse",
         "raw": "",
-        "forcedRawNodeInput": "lighthouse --network mainnet beacon --execution-jwt /root/.lighthouse/jwtsecret"
+        "forcedRawNodeInput": "lighthouse beacon --execution-jwt /root/.lighthouse/jwtsecret"
       }
     },
     "architectures": {
@@ -63,10 +63,36 @@
       "infoDescription": "Used to specify a custom root data directory for lighthouse keys and databases. Defaults to $HOME/.lighthouse/{network} where network is the value of the `network` flag Note: Users should specify separate custom datadirs for different networks.",
       "documentation": "https://lighthouse-book.sigmaprime.io/advanced-datadir.html?highlight=--datadir#relative-paths"
     },
+    "network": {
+      "displayName": "Network (Lighthouse)",
+      "cliConfigPrefix": "--network ",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet --checkpoint-sync-url https://mainnet.checkpoint.sigp.io"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "checkpointSyncUrl": {
       "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpoint-sync-url ",
-      "defaultValue": "https://mainnet.checkpoint.sigp.io",
       "uiControl": {
         "type": "text"
       }

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -11,12 +11,12 @@
         "http": "Enabled",
         "httpPort": "5052",
         "executionEndpoint": "http://host.containers.internal:8551",
-        "checkpointSyncUrl": "https://beaconstate-mainnet.chainsafe.io"
+        "network" : "Mainnet"
       },
       "docker": {
         "containerVolumePath": "/usr/app/data",
         "raw": "",
-        "forcedRawNodeInput": "beacon --network mainnet --rest.address 0.0.0.0 --dataDir /usr/app/data --jwt-secret /usr/app/data/jwtsecret"
+        "forcedRawNodeInput": "beacon --rest.address 0.0.0.0 --dataDir /usr/app/data --jwt-secret /usr/app/data/jwtsecret"
       }
     }
   },
@@ -52,10 +52,36 @@
       },
       "infoDescription": "Lodestar root directory"
     },
+    "network": {
+      "displayName": "Network (Lodestar)",
+      "cliConfigPrefix": "--network ",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet --checkpointSyncUrl https://mainnet.checkpoint.sigp.io"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "checkpointSyncUrl": {
       "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpointSyncUrl ",
-      "defaultValue": "https://beaconstate-mainnet.chainsafe.io",
       "uiControl": {
         "type": "text"
       }

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -63,6 +63,33 @@
         "type": "filePath"
       }
     },
+    "network": {
+      "displayName": "Network (Nethermind)",
+      "cliConfigPrefix": "--config ",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "http": {
       "displayName": "RPC HTTP connections",
       "category": "RPC APIs",

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -12,12 +12,13 @@
         "httpPort": "5052",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
-        "executionEndpoint": "\"http://host.containers.internal:8551\""
+        "executionEndpoint": "\"http://host.containers.internal:8551\"",
+        "network" : "Mainnet"
       },
       "docker": {
         "containerVolumePath": "/home/user/data",
         "raw": " --user 0",
-        "forcedRawNodeInput": "--data-dir=/home/user/data/beacon_node/mainnet_0 --network=mainnet --web3-url=http://host.containers.internal:8551 --jwt-secret=/home/user/data/jwtsecret"
+        "forcedRawNodeInput": "--data-dir=/home/user/data --web3-url=http://host.containers.internal:8551 --jwt-secret=/home/user/data/jwtsecret"
       }
     },
     "binaryDownload": {
@@ -55,10 +56,36 @@
       "infoDescription": "Nimbus root directory",
       "documentation": "https://nimbus.guide/options.html"
     },
+    "network": {
+      "displayName": "Network (Nimbus)",
+      "cliConfigPrefix": "--network=",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet --trusted-node-url=https://beaconstate.ethstaker.cc"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "checkpointSyncUrl": {
       "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--trusted-node-url=",
-      "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
         "type": "text"
       }

--- a/src/common/NodeSpecs/nitro/nitro-v1.0.0.json
+++ b/src/common/NodeSpecs/nitro/nitro-v1.0.0.json
@@ -1,0 +1,159 @@
+{
+  "specId": "nitro",
+  "version": "1.0.0",
+  "displayName": "Arbitrum Nitro",
+  "execution": {
+    "executionTypes": ["docker"],
+    "defaultExecutionType": "docker",
+    "imageName": "docker.io/offchainlabs/nitro-node:v2.0.14-2baa834",
+    "input": {
+      "defaultConfig": {
+        "ethMainnetRpcUrl": "https://mainnet.infura.io/v3/97fa4206f9bd4ea9957f9a82a2b2e4d0",
+        "httpAddress" : "0.0.0.0",
+        "l2ChainId" : "42161",
+        "httpCorsDomains": "http://localhost",
+        "httpVirtualHosts": "localhost,host.containers.internal"
+      },
+      "docker": {
+        "containerVolumePath": "/home/user/.arbitrum",
+        "raw": " --user user",
+        "forcedRawNodeInput" : "--l1.chain-id=1 --init.url=\"https://snapshot.arbitrum.foundation/arb1/nitro-pruned.tar\" --log-level=5"
+      }
+    },
+    "dependencies": ["L1/ExecutionClient"]
+  },
+  "category": "Ethereum/L2",
+  "rpcTranslation": "eth-l2",
+  "systemRequirements": {
+    "documentationUrl": "https://docs.arbitrum.io/node-running/how-tos/running-a-full-node#minimum-hardware-configuration",
+    "cpu": {
+      "cores": 4
+    },
+    "memory": {
+      "minSizeGBs": 8
+    },
+    "storage": {
+      "minSizeGBs": 1600,
+      "ssdRequired": true
+    },
+    "internet": {
+      "minDownloadSpeedMbps": 25,
+      "minUploadSpeedMbps": 10
+    },
+    "docker": {
+      "required": true
+    }
+  },
+  "configTranslation": {
+    "ethMainnetRpcUrl": {
+      "displayName": "Ethereum Mainnet RPC Endpoint (local node http://host.containers.internal:8545 or provider)",
+      "cliConfigPrefix": "--l1.url=",
+      "defaultValue": "https://mainnet.infura.io/v3/97fa4206f9bd4ea9957f9a82a2b2e4d0",
+      "uiControl": {
+        "type": "text"
+      },
+      "addNodeFlow": "required"
+    },
+    "l2ChainId": {
+      "displayName": "Arbitrum L2 Chain ID",
+      "cliConfigPrefix": "--l2.chain-id=",
+      "defaultValue": "42161",
+      "uiControl": {
+        "type": "text"
+      }
+    },
+    "httpAddress": {
+      "displayName": "HTTP-RPC server listening interface",
+      "cliConfigPrefix": "--http.addr=",
+      "defaultValue": "0.0.0.0",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
+    },
+    "httpPort": {
+      "displayName": "HTTP-RPC server listening port",
+      "cliConfigPrefix": "--http.port=",
+      "defaultValue": "8547",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
+    },
+    "httpVirtualHosts": {
+      "displayName": "HTTP RPC virtual hostnames list",
+      "cliConfigPrefix": "--http.vhosts=",
+      "defaultValue": "localhost,host.containers.internal",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Comma separated list of virtual hostnames from which to accept authentication requests for engine api's (server enforced). Accepts '*' wildcard. Default value (localhost)"
+    },
+    "websockets": {
+      "displayName": "rpc websocket connections (*BeaconNodes may require websocket connections)",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Enabled",
+            "config": "--ws"
+          },
+          {
+            "value": "Disabled"
+          }
+        ]
+      },
+      "defaultValue": "Disabled"
+    },
+    "httpApis": {
+      "displayName": "Enabled HTTP APIs",
+      "cliConfigPrefix": "--http.api=",
+      "defaultValue": "eth,net,web3,debug",
+      "valuesJoinStr": ",",
+      "uiControl": {
+        "type": "select/multiple",
+        "controlTranslations": [
+          {
+            "value": "eth",
+            "config": "Eth"
+          },
+          {
+            "value": "net",
+            "config": "Net"
+          },
+          {
+            "value": "web3",
+            "config": "Web3"
+          },
+          {
+            "value": "debug",
+            "config": "Debug"
+          },
+
+          {
+            "value": "personal",
+            "config": "Personal"
+          },
+          {
+            "value": "admin",
+            "config": "Admin"
+          }
+        ]
+      }
+    },
+    "httpCorsDomains": {
+      "displayName": "HTTP-RPC CORS domains",
+      "cliConfigPrefix": "--http.corsdomain=",
+      "defaultValue": "*",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "Change where the node accepts http connections (use comma separated urls)"
+    }
+  },
+  "documentation": {
+    "default": "https://arbitrum.io/",
+    "docker": "https://developer.offchainlabs.com/docs/running_node"
+  },
+  "iconUrl": "https://arbitrum.io/wp-content/uploads/2021/08/Arbitrum_Symbol-Full-color-White-background-937x1024.png"
+}

--- a/src/common/NodeSpecs/nitro/nitro-v1.0.0.json
+++ b/src/common/NodeSpecs/nitro/nitro-v1.0.0.json
@@ -8,15 +8,16 @@
     "imageName": "docker.io/offchainlabs/nitro-node:v2.0.14-2baa834",
     "input": {
       "defaultConfig": {
-        "ethMainnetRpcUrl": "https://mainnet.infura.io/v3/97fa4206f9bd4ea9957f9a82a2b2e4d0",
+        "ethMainnetRpcUrl": "",
         "httpAddress" : "0.0.0.0",
+        "httpPort" : "8547",
         "l2ChainId" : "42161",
         "httpCorsDomains": "http://localhost",
         "httpVirtualHosts": "localhost,host.containers.internal"
       },
       "docker": {
         "containerVolumePath": "/home/user/.arbitrum",
-        "raw": " --user user",
+        "raw": "",
         "forcedRawNodeInput" : "--l1.chain-id=1 --init.url=\"https://snapshot.arbitrum.foundation/arb1/nitro-pruned.tar\" --log-level=5"
       }
     },
@@ -48,7 +49,7 @@
     "ethMainnetRpcUrl": {
       "displayName": "Ethereum Mainnet RPC Endpoint (local node http://host.containers.internal:8545 or provider)",
       "cliConfigPrefix": "--l1.url=",
-      "defaultValue": "https://mainnet.infura.io/v3/97fa4206f9bd4ea9957f9a82a2b2e4d0",
+      "defaultValue": "",
       "uiControl": {
         "type": "text"
       },

--- a/src/common/NodeSpecs/op-geth/op-geth-v1.0.0.json
+++ b/src/common/NodeSpecs/op-geth/op-geth-v1.0.0.json
@@ -23,7 +23,7 @@
     "imageName": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101106.0"
   },
   "category": "L2/ExecutionClient",
-  "rpcTranslation": "eth-l1",
+  "rpcTranslation": "eth-l2",
   "systemRequirements": {
     "documentationUrl": "https://geth.ethereum.org/docs/interface/hardware",
     "cpu": {

--- a/src/common/NodeSpecs/op-node/op-node-v1.0.0.json
+++ b/src/common/NodeSpecs/op-node/op-node-v1.0.0.json
@@ -20,8 +20,8 @@
     },
     "imageName": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.1.3"
   },
-  "category": "L2/ExecutionClient",
-  "rpcTranslation": "eth-l1",
+  "category": "L2/ConsensusClient",
+  "rpcTranslation": "eth-l1-beacon",
   "systemRequirements": {
     "documentationUrl": "https://geth.ethereum.org/docs/interface/hardware",
     "cpu": {

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -13,7 +13,7 @@
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "http://host.containers.internal:8551",
-        "checkpointSyncUrl": "https://beaconstate.ethstaker.cc"
+        "network" : "Mainnet"
       },
       "docker": {
         "containerVolumePath": "/data",
@@ -54,10 +54,35 @@
       "infoDescription": "Prysm root directory",
       "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters/"
     },
+    "network": {
+      "displayName": "Network (Prysm)",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "--mainnet --checkpoint-sync-url=https://beaconstate.ethstaker.cc"
+          },
+          {
+            "value": "Holesky",
+            "config": "--holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "--goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "--sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "checkpointSyncUrl": {
       "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--checkpoint-sync-url=",
-      "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
         "type": "text"
       }

--- a/src/common/NodeSpecs/reth/reth-v1.0.0.json
+++ b/src/common/NodeSpecs/reth/reth-v1.0.0.json
@@ -46,6 +46,33 @@
     }
   },
   "configTranslation": {
+    "network": {
+      "displayName": "Network (Reth)",
+      "cliConfigPrefix": "--chain ",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "http": {
       "displayName": "RPC HTTP connections",
       "uiControl": {

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -9,11 +9,11 @@
     "input": {
       "defaultConfig": {
         "http": "Enabled",
-        "httpPort": "5051",
+        "httpPort": "5052",
         "httpHostAddress": "0.0.0.0",
         "httpCorsDomains": "\"http://localhost\"",
         "executionEndpoint": "http://host.containers.internal:8551",
-        "checkpointSyncUrl": "https://beaconstate.ethstaker.cc"
+        "network" : "Mainnet"
       },
       "docker": {
         "containerVolumePath": "/var/lib/teku",
@@ -55,10 +55,36 @@
       "infoDescription": "Teku root directory",
       "documentation": "https://docs.teku.consensys.net/en/stable/Reference/CLI/CLI-Syntax/#data-base-path-data-path"
     },
+    "network": {
+      "displayName": "Network (Teku)",
+      "cliConfigPrefix": "--network=",
+      "defaultValue": "Mainnet",
+      "uiControl": {
+        "type": "select/single",
+        "controlTranslations": [
+          {
+            "value": "Mainnet",
+            "config": "mainnet --initial-state=https://beaconstate.ethstaker.cc"
+          },
+          {
+            "value": "Holesky",
+            "config": "holesky"
+          },
+          {
+            "value": "Goerli",
+            "config": "goerli"
+          },
+          {
+            "value": "Sepolia",
+            "config": "sepolia"
+          }
+        ]
+      },
+      "addNodeFlow": "advanced"
+    },
     "checkpointSyncUrl": {
       "displayName": "Trusted checkpoint sync URL",
       "cliConfigPrefix": "--initial-state=",
-      "defaultValue": "https://beaconstate.ethstaker.cc",
       "uiControl": {
         "type": "text"
       }
@@ -96,7 +122,7 @@
     "httpPort": {
       "displayName": "HTTP server listening port",
       "cliConfigPrefix": "--rest-api-port=",
-      "defaultValue": "5051",
+      "defaultValue": "5052",
       "uiControl": {
         "type": "text"
       },

--- a/src/common/node.ts
+++ b/src/common/node.ts
@@ -48,6 +48,7 @@ export type NodeRuntime = {
   // execPath?: string;
   dataDir: string;
   processIds?: string[];
+  initialized?: boolean;
   usage: {
     diskGBs: MetricData[] | [];
     memoryBytes: MetricData[] | [];

--- a/src/common/nodeConfig.ts
+++ b/src/common/nodeConfig.ts
@@ -22,6 +22,8 @@ export type ConfigTranslationControl =
 
 export type ConfigValue = string | string[] | undefined;
 
+export type ConfigTranslationAddNodeFlow = 'required' | 'advanced';
+
 export type ConfigTranslation = {
   displayName: string;
   uiControl: ConfigTranslationControl;
@@ -34,6 +36,7 @@ export type ConfigTranslation = {
   documentation?: string;
   infoDescription?: string;
   warning?: string;
+  addNodeFlow?: ConfigTranslationAddNodeFlow;
 };
 
 export type ConfigKey = string;

--- a/src/common/nodeSpec.ts
+++ b/src/common/nodeSpec.ts
@@ -40,6 +40,8 @@ export type DockerExecution = BaseNodeExecution & {
       containerVolumePath: string;
       raw?: string;
       forcedRawNodeInput?: string;
+      // optional, one time command run after creating a node and before the first run
+      initNodeCommand?: string;
     };
   };
 };

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, readFile, rm } from 'fs/promises';
+import { access, mkdir, readFile, rm, chmod } from 'fs/promises';
 import path from 'path';
 import { app } from 'electron';
 import checkDiskSpace from 'check-disk-space';
@@ -36,8 +36,14 @@ export const checkAndOrCreateDir = async (dirPath: string) => {
     logger.info(`checkAndOrCreateDir dirPath ${dirPath} exists`);
   } catch {
     logger.info(`checkAndOrCreateDir making dirPath ${dirPath}...`);
-    await mkdir(dirPath, { recursive: true });
-    logger.info(`checkAndOrCreateDir making dirPath ${dirPath}...`);
+    // make dir so any user can read and write
+    await mkdir(dirPath, { recursive: true, mode: 0o777 });
+    // A node (hubble) complains that the dir needs `chmod 777` even though
+    //  mkdir is called with 777 permissions.
+    await chmod(dirPath, 0o777);
+    logger.info(
+      `checkAndOrCreateDir made dirPath with 0o777 permissions ${dirPath}...`,
+    );
   }
 };
 

--- a/src/main/nodeLibraryManager.ts
+++ b/src/main/nodeLibraryManager.ts
@@ -2,6 +2,7 @@ import ethereumv1 from '../common/NodeSpecs/ethereum/ethereum-v1.0.0.json';
 import optimismv1 from '../common/NodeSpecs/optimism/optimism-v1.0.0.json';
 import basev1 from '../common/NodeSpecs/base/base-v1.0.0.json';
 import farcasterv1 from '../common/NodeSpecs/farcaster/farcaster-v1.0.0.json';
+import arbitrumv1 from '../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json';
 
 import besuv1 from '../common/NodeSpecs/besu/besu-v1.0.0.json';
 import nethermindv1 from '../common/NodeSpecs/nethermind/nethermind-v1.0.0.json';
@@ -14,13 +15,14 @@ import tekuv1 from '../common/NodeSpecs/teku/teku-v1.0.0.json';
 import lighthousev1 from '../common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json';
 import prysmv1 from '../common/NodeSpecs/prysm/prysm-v1.0.0.json';
 
-import arbitrumv1 from '../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json';
 import pathfinderv1 from '../common/NodeSpecs/pathfinder/pathfinder-v1.0.0.json';
 
 import opGethv1 from '../common/NodeSpecs/op-geth/op-geth-v1.0.0.json';
 import opNodev1 from '../common/NodeSpecs/op-node/op-node-v1.0.0.json';
 
 import hubblev1 from '../common/NodeSpecs/hubble/hubble-v1.0.0.json';
+
+import nitrov1 from '../common/NodeSpecs/nitro/nitro-v1.0.0.json';
 
 import logger from './logger';
 import {
@@ -49,6 +51,7 @@ export const initialize = async () => {
     lighthousev1,
     prysmv1,
     arbitrumv1,
+    nitrov1,
     pathfinderv1,
     opGethv1,
     opNodev1,
@@ -65,7 +68,13 @@ export const initialize = async () => {
   updateNodeLibrary(nodeSpecBySpecId);
 
   const nodePackageSpecBySpecId: NodePackageLibrary = {};
-  const packageSpecs = [ethereumv1, optimismv1, basev1, farcasterv1];
+  const packageSpecs = [
+    ethereumv1,
+    farcasterv1,
+    arbitrumv1,
+    optimismv1,
+    basev1,
+  ];
   packageSpecs.forEach((spec) => {
     try {
       nodePackageSpecBySpecId[spec.specId] = spec as NodePackageSpecification;

--- a/src/main/nodeManager.ts
+++ b/src/main/nodeManager.ts
@@ -39,6 +39,10 @@ export const addNode = async (
     storageLocation ?? getNodesDirPath(),
   );
   console.log('adding node with dataDir: ', dataDir);
+  console.log(
+    'adding node with initialConfigFromUser: ',
+    initialConfigFromUser,
+  );
   const nodeRuntime: NodeRuntime = {
     dataDir,
     usage: {

--- a/src/main/nodeManager.ts
+++ b/src/main/nodeManager.ts
@@ -38,6 +38,12 @@ export const addNode = async (
     `${nodeSpec.specId}-${utcTimestamp}`,
     storageLocation ?? getNodesDirPath(),
   );
+  // We really do not want to have conditionals for specific nodes, however,
+  //  this is justified as we iterate quickly for funding and prove NN works
+  if (nodeSpec.specId === 'hubble') {
+    await makeNodeDir('hub', dataDir);
+    await makeNodeDir('rocks', dataDir);
+  }
   console.log('adding node with dataDir: ', dataDir);
   console.log(
     'adding node with initialConfigFromUser: ',

--- a/src/main/nodePackageManager.ts
+++ b/src/main/nodePackageManager.ts
@@ -22,6 +22,7 @@ import {
   stopNode,
 } from './nodeManager';
 import { createJwtSecretAtDirs } from './util/jwtSecrets';
+import { ConfigValuesMap } from '../common/nodeConfig';
 
 // Created when adding a node and is used to pair a node spec and config
 // for a specific node package service
@@ -29,6 +30,7 @@ export type AddNodePackageNodeService = {
   serviceId: string;
   serviceName: string;
   spec: NodeSpecification;
+  initialConfigValues?: ConfigValuesMap;
 };
 
 export const addNodePackage = async (
@@ -71,7 +73,16 @@ export const addNodePackage = async (
       );
       if (nodePackageServiceSpec) {
         // Only create required nodes right now?
-        const node = await addNode(service.spec, settings.storageLocation);
+        const node = await addNode(
+          service.spec,
+          settings.storageLocation,
+          service.initialConfigValues,
+        );
+        console.log(
+          'nodePackageManager: adding node with initialConfigValues: ',
+          node,
+          service.initialConfigValues,
+        );
         nodeServices.push({
           serviceId: service.serviceId,
           serviceName: service.serviceName,

--- a/src/main/nodePackageManager.ts
+++ b/src/main/nodePackageManager.ts
@@ -14,13 +14,7 @@ import Node, {
 } from '../common/node';
 import * as nodePackageStore from './state/nodePackages';
 import { deleteDisk, getNodesDirPath, makeNodeDir } from './files';
-import {
-  addNode,
-  removeAllNodes,
-  removeNode,
-  startNode,
-  stopNode,
-} from './nodeManager';
+import { addNode, removeNode, startNode, stopNode } from './nodeManager';
 import { createJwtSecretAtDirs } from './util/jwtSecrets';
 import { ConfigValuesMap } from '../common/nodeConfig';
 
@@ -178,8 +172,7 @@ export const removeNodePackage = async (
   nodeId: NodeId,
   options: { isDeleteStorage: boolean },
 ): Promise<NodePackage> => {
-  // todo: check if node package can be removed. Is it stopped?
-  // todo: stop & remove container
+  // Stop package if running (this makes delete files and other things smoother)
   logger.info(
     `Remove node package ${nodeId} and delete storage? ${options.isDeleteStorage}`,
   );
@@ -213,13 +206,12 @@ export const removeNodePackage = async (
 };
 
 /**
- * Removes all node packages, then remove all node services and deletes their storage data
+ * Removes all node packages, which removes all node services and deletes their storage data
  */
 export const removeAllNodePackages = async () => {
   const nodes = nodePackageStore.getNodePackages();
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
-    await nodePackageStore.removeNodePackage(node.id);
+    await removeNodePackage(node.id, { isDeleteStorage: true });
   }
-  await removeAllNodes();
 };

--- a/src/main/podman/install/install.ts
+++ b/src/main/podman/install/install.ts
@@ -4,7 +4,7 @@ import installOnMac from './installOnMac';
 import installOnWindows from './installOnWindows';
 import installOnLinux from './installOnLinux';
 
-export const VERSION = '4.6.0';
+export const VERSION = '4.7.0';
 
 // eslint-disable-next-line
 const installPodman = async (): Promise<any> => {

--- a/src/main/podman/podman.ts
+++ b/src/main/podman/podman.ts
@@ -248,6 +248,7 @@ export const sendLogsToUI = (node: Node) => {
         send('nodeLogs', parsePodmanLogMetadata(log, node.spec.specId));
       } catch (err) {
         logger.error(`Error parsing podman event log ${log}`, err);
+        send('nodeLogs', { message: log });
       }
     });
   }
@@ -268,6 +269,7 @@ export const sendLogsToUI = (node: Node) => {
         // send('nodeLogs', log);
       } catch (err) {
         logger.error(`Error parsing podman event log ${log}`, err);
+        send('nodeLogs', { message: log });
       }
     });
   }
@@ -497,7 +499,7 @@ export const createRunCommand = (node: Node): string => {
   nodeInput += ` ${cliConfigInput}`;
 
   // -q quiets podman logs (pulling new image logs) so we can parse the containerId
-  const podmanCommand = `run -q -d --restart on-failure:3 --name ${specId} ${finalPodmanInput} ${imageName} ${nodeInput}`;
+  const podmanCommand = `run -q -d --name ${specId} ${finalPodmanInput} ${imageName} ${nodeInput}`;
   logger.info(`podman run command ${podmanCommand}`);
   return podmanCommand;
 };

--- a/src/main/util/nodeLogUtils.ts
+++ b/src/main/util/nodeLogUtils.ts
@@ -84,6 +84,15 @@ const trimLogHeader = (log: string, client: string) => {
       '',
     );
   }
+  if (client === 'nitro') {
+    // Example: INFO [09-26|23:52:47.760]
+    // Pattern: INFO/WARN/ERROR [MM-DD|HH:mm:ss.SSS]
+    return log.replace(
+      /(INFO|WARN|ERROR)\s+\[\d{2}-\d{2}\|\d{2}:\d{2}:\d{2}\.\d{3}\] /,
+      '',
+    );
+  }
+
   // Other Ethereum clients could be added here as needed...
 
   // If the client is not recognized, return the original log

--- a/src/renderer/Generics/redesign/DynamicSettings/DynamicSettings.tsx
+++ b/src/renderer/Generics/redesign/DynamicSettings/DynamicSettings.tsx
@@ -39,6 +39,7 @@ const DynamicSettings = ({
         onChange,
       }),
     );
+    console.log('conifgs dynamic: ', configValuesMap);
   }, [categoryConfigs, configValuesMap, isDisabled, onChange]);
 
   if (!categoryConfigs) {

--- a/src/renderer/Generics/redesign/DynamicSettings/DynamicSettings.tsx
+++ b/src/renderer/Generics/redesign/DynamicSettings/DynamicSettings.tsx
@@ -39,7 +39,6 @@ const DynamicSettings = ({
         onChange,
       }),
     );
-    console.log('conifgs dynamic: ', configValuesMap);
   }, [categoryConfigs, configValuesMap, isDisabled, onChange]);
 
   if (!categoryConfigs) {

--- a/src/renderer/Generics/redesign/Input/Input.tsx
+++ b/src/renderer/Generics/redesign/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { IconId } from 'renderer/assets/images/icons';
 import { Icon } from '../Icon/Icon';
 import {
@@ -45,9 +45,17 @@ const Input = ({
   disabled,
   onChange = () => {},
 }: InputProps) => {
+  const [sValue, setValue] = useState<string>('');
+
+  useEffect(() => {
+    setValue(value || '');
+  }, [value]);
+
   const onChangeAction = (evt: ChangeEvent<HTMLInputElement>) => {
+    const newValue = evt.target.value;
+    setValue(newValue);
     if (onChange) {
-      onChange(evt.target.value);
+      onChange(newValue);
     }
   };
   const leftIconStyle = leftIconId ? 'leftIcon' : '';
@@ -64,7 +72,7 @@ const Input = ({
           type: 'text',
           className: [inputContainer, leftIconStyle, rightIconStyle].join(' '),
           placeholder,
-          value,
+          value: sValue,
           ...(disabled && { disabled }),
           ...(required && { required }),
           onChange: (evt) => {

--- a/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
+++ b/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
@@ -38,6 +38,8 @@ const LabelSettingsSection = ({
 }: LabelSettingsSectionProps) => {
   const { t: g } = useTranslation('genericComponents');
 
+  // console.log('conifgs items', JSON.stringify(items));
+
   return (
     <div className={[sectionContainer, type].join(' ')}>
       {sectionTitle && (

--- a/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
+++ b/src/renderer/Generics/redesign/LabelSetting/LabelValuesSection.tsx
@@ -38,8 +38,6 @@ const LabelSettingsSection = ({
 }: LabelSettingsSectionProps) => {
   const { t: g } = useTranslation('genericComponents');
 
-  // console.log('conifgs items', JSON.stringify(items));
-
   return (
     <div className={[sectionContainer, type].join(' ')}>
       {sectionTitle && (

--- a/src/renderer/Presentational/AddNode/AddNode.tsx
+++ b/src/renderer/Presentational/AddNode/AddNode.tsx
@@ -45,6 +45,13 @@ const nodeOptions = [
     label: 'Farcaster',
     info: 'A protocol for decentralized social apps',
   },
+  {
+    iconId: 'arbitrum',
+    title: 'Arbitrum One',
+    value: 'arbitrum',
+    label: 'Arbitrum One',
+    info: 'Welcome to the future of Ethereum',
+  },
 ];
 
 let alphaModalRendered = false;

--- a/src/renderer/Presentational/AddNode/AddNode.tsx
+++ b/src/renderer/Presentational/AddNode/AddNode.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { NodeLibrary } from 'main/state/nodeLibrary';
-import { ModalConfig } from '../ModalManager/modalUtils';
 import {
   container,
   descriptionFont,
@@ -61,14 +59,14 @@ export interface AddNodeProps {
   onChange?: (newValue: AddNodeValues) => void;
   nodeConfig?: AddNodeValues;
   setNode?: (nodeSelection: SelectOption, object: AddNodeValues) => void;
-  modalOnChangeConfig?: (config: ModalConfig) => void;
+  shouldHideTitle?: boolean;
 }
 
 const AddNode = ({
   nodeConfig,
   setNode,
-  modalOnChangeConfig,
   onChange,
+  shouldHideTitle,
 }: AddNodeProps) => {
   const { t } = useTranslation();
   const [sSelectedNode, setSelectedNode] = useState<SelectOption>(
@@ -82,12 +80,7 @@ const AddNode = ({
     const fetchData = async () => {
       const hasSeenAlpha = await electron.getSetHasSeenAlphaModal();
       setHasSeenAlphaModal(hasSeenAlpha || false);
-      const nodeLibrary: NodeLibrary = await electron.getNodeLibrary();
-      if (modalOnChangeConfig) {
-        modalOnChangeConfig({
-          nodeLibrary,
-        });
-      }
+
       // Modal Parent needs updated with the default initial value
       // Todo: due to a JS closure bug with modalOnChangeConfig, we are setting the selected node here
       const ethNodeConfig = {
@@ -107,8 +100,6 @@ const AddNode = ({
       // clear any client selections when the node changes
       const nodeConfig = {
         node: sSelectedNode,
-        executionClient: undefined,
-        consensusClient: undefined,
       };
       if (newNode) {
         setSelectedNode(newNode);
@@ -143,7 +134,9 @@ const AddNode = ({
 
   return (
     <div className={container}>
-      {!modalOnChangeConfig && <div className={titleFont}>{t('AddNode')}</div>}
+      {shouldHideTitle !== true && (
+        <div className={titleFont}>{t('AddYourFirstNode')}</div>
+      )}
       <div className={descriptionContainer}>
         <div className={descriptionFont}>
           <>{t('AddNodeDescription')}</>

--- a/src/renderer/Presentational/AddNode/AddNode.tsx
+++ b/src/renderer/Presentational/AddNode/AddNode.tsx
@@ -40,13 +40,13 @@ const nodeOptions = [
   //   label: 'Optimism',
   //   info: 'Built by the OP Collective!',
   // },
-  // {
-  //   iconId: 'farcaster',
-  //   title: 'Farcaster',
-  //   value: 'farcaster',
-  //   label: 'Farcaster',
-  //   info: 'A protocol for decentralized social apps',
-  // },
+  {
+    iconId: 'farcaster',
+    title: 'Farcaster',
+    value: 'farcaster',
+    label: 'Farcaster',
+    info: 'A protocol for decentralized social apps',
+  },
 ];
 
 let alphaModalRendered = false;

--- a/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
@@ -5,7 +5,6 @@ import {
   NodeLibrary,
   NodePackageLibrary,
 } from '../../../main/state/nodeLibrary';
-import { ModalConfig } from '../ModalManager/modalUtils';
 import {
   container,
   descriptionFont,
@@ -43,7 +42,7 @@ export interface AddNodeConfigurationProps {
   nodeId?: NodeId;
   onChange?: (newValue: AddNodeConfigurationValues) => void;
   nodePackageConfig?: AddNodeConfigurationValues;
-  modalOnChangeConfig?: (config: ModalConfig) => void;
+  shouldHideTitle?: boolean;
 }
 
 const nodeSpecToSelectOption = (nodeSpec: NodeSpecification) => {
@@ -61,7 +60,7 @@ const nodeSpecToSelectOption = (nodeSpec: NodeSpecification) => {
 const AddNodeConfiguration = ({
   nodeId,
   nodePackageConfig,
-  modalOnChangeConfig,
+  shouldHideTitle,
   onChange,
 }: AddNodeConfigurationProps) => {
   const { t } = useTranslation();
@@ -147,17 +146,12 @@ const AddNodeConfiguration = ({
     const fetchData = async () => {
       const defaultNodesStorageDetails =
         await electron.getNodesDefaultStorageLocation();
-      const nodeLibrary: NodeLibrary = await electron.getNodeLibrary();
-      const nodePackageLibrary: NodePackageLibrary =
-        await electron.getNodePackageLibrary();
       console.log('defaultNodesStorageDetails', defaultNodesStorageDetails);
       setNodeStorageLocation(defaultNodesStorageDetails.folderPath);
-      if (modalOnChangeConfig) {
-        modalOnChangeConfig({
-          selectedClients: sClientSelections,
+      if (onChange) {
+        onChange({
+          clientSelections: sClientSelections,
           storageLocation: defaultNodesStorageDetails.folderPath,
-          nodeLibrary,
-          nodePackageLibrary,
         });
       }
       setNodeStorageLocationFreeStorageGBs(
@@ -166,7 +160,7 @@ const AddNodeConfiguration = ({
     };
     fetchData();
 
-    // Modal Parent needs updated with the default initial value
+    // Parent needs updated with the default initial value
     if (setClientSelections) {
       setClientSelections(sClientSelections);
     }
@@ -202,7 +196,7 @@ const AddNodeConfiguration = ({
 
   return (
     <div className={container}>
-      {!modalOnChangeConfig && (
+      {shouldHideTitle !== true && (
         <div className={titleFont}>
           {t('LaunchAVarNode', { nodeName: sNodePackageSpec.displayName })}
         </div>
@@ -253,13 +247,6 @@ const AddNodeConfiguration = ({
           setClientConfigValues(newClientConfigValues);
         }}
       />
-      {/* <DynamicSettings
-        type="modal"
-        categoryConfigs={categoryConfigs}
-        configValuesMap={configValuesMap}
-        isDisabled={false}
-        onChange={onChange}
-      /> */}
 
       <HorizontalLine />
       <p className={sectionFont}>{tGeneric('DataLocation')}</p>
@@ -275,8 +262,8 @@ const AddNodeConfiguration = ({
           console.log('storageLocationDetails', storageLocationDetails);
           if (storageLocationDetails) {
             setNodeStorageLocation(storageLocationDetails.folderPath);
-            if (modalOnChangeConfig) {
-              modalOnChangeConfig({
+            if (onChange) {
+              onChange({
                 storageLocation: storageLocationDetails.folderPath,
               });
             }

--- a/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { mergeObjectReducer } from './deepMerge';
 import {
   NodeLibrary,
   NodePackageLibrary,
@@ -10,6 +11,7 @@ import {
   descriptionFont,
   sectionFont,
   titleFont,
+  advancedOptionsLink,
 } from './addNodeConfiguration.css';
 import SpecialSelect, {
   SelectOption,
@@ -28,6 +30,7 @@ import ExternalLink from '../../Generics/redesign/Link/ExternalLink';
 import InitialClientConfigs, {
   ClientConfigValues,
 } from './InitialClientConfigs';
+import DropdownLink from '../../Generics/redesign/Link/DropdownLink';
 
 export type ClientSelections = {
   [serviceId: string]: SelectOption;
@@ -81,13 +84,17 @@ const AddNodeConfiguration = ({
   const [sClientNodeSpecifications, setClientNodeSpecifications] = useState<
     NodeSpecification[]
   >([]);
-  const [sClientConfigValues, setClientConfigValues] =
-    useState<ClientConfigValues>({});
+  const [sClientConfigValues, dispatchClientConfigValues] = useReducer(
+    mergeObjectReducer,
+    {},
+  );
 
   const [
     sNodeStorageLocationFreeStorageGBs,
     setNodeStorageLocationFreeStorageGBs,
   ] = useState<number>();
+  const [sIsAdvancedOptionsOpen, setIsAdvancedOptionsOpen] =
+    useState<boolean>();
 
   useEffect(() => {
     const fetchNodeLibrarys = async () => {
@@ -243,8 +250,9 @@ const AddNodeConfiguration = ({
       {/* Initial client settings, required and optional */}
       <InitialClientConfigs
         clientSpecs={sClientNodeSpecifications}
+        addNodeFlowSelection="required"
         onChange={(newClientConfigValues) => {
-          setClientConfigValues(newClientConfigValues);
+          dispatchClientConfigValues(newClientConfigValues);
         }}
       />
 
@@ -275,6 +283,29 @@ const AddNodeConfiguration = ({
           }
         }}
       />
+
+      <HorizontalLine />
+      {/* Initial client settings, required and optional */}
+      <div className={advancedOptionsLink}>
+        <DropdownLink
+          text={`${
+            sIsAdvancedOptionsOpen
+              ? t('HideAdvancedOptions')
+              : t('ShowAdvancedOptions')
+          }`}
+          onClick={() => setIsAdvancedOptionsOpen(!sIsAdvancedOptionsOpen)}
+          isDown={!sIsAdvancedOptionsOpen}
+        />
+      </div>
+      {sIsAdvancedOptionsOpen && (
+        <InitialClientConfigs
+          clientSpecs={sClientNodeSpecifications}
+          addNodeFlowSelection="advanced"
+          onChange={(newClientConfigValues) => {
+            dispatchClientConfigValues(newClientConfigValues);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -77,6 +77,8 @@ const InitialClientConfigs = ({
 
   return (
     <div>
+      {/* Initial client settings, required and optional */}
+
       {Object.keys(sClientConfigTranslations)?.map((clientId: string) => {
         const singleClientConfigTranslation =
           sClientConfigTranslations[clientId];
@@ -90,7 +92,7 @@ const InitialClientConfigs = ({
           }
         });
         const singleClientConfigValues = sClientConfigValues[clientId];
-
+        console.log('render conifgs: ', singleClientConfigValues);
         return (
           <React.Fragment key={clientId}>
             <DynamicSettings
@@ -108,6 +110,7 @@ const InitialClientConfigs = ({
                   'initial client conifgs onChange: ',
                   configKey,
                   newValue,
+                  sClientConfigValues,
                 );
                 setClientConfigValues({
                   ...sClientConfigValues,
@@ -121,10 +124,6 @@ const InitialClientConfigs = ({
           </React.Fragment>
         );
       })}
-
-      {/* Initial client settings, required and optional */}
-
-      {/* todo: option */}
     </div>
   );
 };

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { NodeSpecification } from '../../../common/nodeSpec';
+import DynamicSettings from '../../Generics/redesign/DynamicSettings/DynamicSettings';
+import {
+  ConfigTranslationMap,
+  ConfigValue,
+  ConfigValuesMap,
+} from '../../../common/nodeConfig';
+
+// The core data structure for this component
+export type ClientConfigValues = {
+  [cliendId: string]: ConfigValuesMap;
+};
+export type ClientConfigTranslations = {
+  // ConfigTranslationMap is a lookup object which defines the UI control for a single config
+  // Record<ConfigKey, ConfigTranslation>;
+  [cliendId: string]: ConfigTranslationMap;
+};
+
+export interface InitialClientConfigsProps {
+  clientSpecs: NodeSpecification[];
+  onChange?: (newClientConfigValues: ClientConfigValues) => void;
+}
+
+const InitialClientConfigs = ({
+  clientSpecs,
+  onChange,
+}: InitialClientConfigsProps) => {
+  const [sClientConfigValues, setClientConfigValues] =
+    useState<ClientConfigValues>({});
+  const [sClientConfigTranslations, setClientConfigTranslations] =
+    useState<ClientConfigTranslations>({});
+
+  useEffect(() => {
+    const clientConfigValues: ClientConfigValues = {};
+    const clientConfigTranslations: ClientConfigTranslations = {};
+    if (clientSpecs) {
+      clientSpecs.forEach((clientSpec: NodeSpecification) => {
+        // if the client is not new, keep the current config
+        // todo: does this cause re-render?
+        if (
+          sClientConfigValues[clientSpec.specId] &&
+          sClientConfigTranslations[clientSpec.specId]
+        ) {
+          clientConfigValues[clientSpec.specId] =
+            sClientConfigValues[clientSpec.specId];
+          clientConfigTranslations[clientSpec.specId] =
+            sClientConfigTranslations[clientSpec.specId];
+        } else {
+          // if the user selectes a different client, initialize the state config translation and values
+          clientConfigValues[clientSpec.specId] = {};
+          clientConfigTranslations[clientSpec.specId] =
+            clientSpec.configTranslation || {};
+        }
+      });
+    }
+    setClientConfigTranslations(clientConfigTranslations);
+    setClientConfigValues(clientConfigValues);
+
+    // we only want to update these values when props.clientSpecs changes
+    // adding the other deps would cause a loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientSpecs]);
+
+  useEffect(() => {
+    console.log('useEffect sClientConfigValues: ', sClientConfigValues);
+    if (onChange) {
+      onChange(sClientConfigValues);
+    }
+    // todo: try useCallback in parent component
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sClientConfigValues]);
+
+  if (!clientSpecs) {
+    return <>No clients found</>;
+  }
+
+  return (
+    <div>
+      {Object.keys(sClientConfigTranslations)?.map((clientId: string) => {
+        const singleClientConfigTranslation =
+          sClientConfigTranslations[clientId];
+        const requiredClientConfigTranslation: ConfigTranslationMap = {};
+
+        // Filter out only node config that is required for the add node flow
+        Object.keys(singleClientConfigTranslation)?.map((configKey) => {
+          const configTranslation = singleClientConfigTranslation[configKey];
+          if (configTranslation.addNodeFlow === 'required') {
+            requiredClientConfigTranslation[configKey] = configTranslation;
+          }
+        });
+        const singleClientConfigValues = sClientConfigValues[clientId];
+
+        return (
+          <React.Fragment key={clientId}>
+            <DynamicSettings
+              type="modal"
+              categoryConfigs={[
+                {
+                  category: '',
+                  configTranslationMap: requiredClientConfigTranslation,
+                },
+              ]}
+              configValuesMap={singleClientConfigValues}
+              isDisabled={false}
+              onChange={(configKey: string, newValue: ConfigValue) => {
+                console.log(
+                  'initial client conifgs onChange: ',
+                  configKey,
+                  newValue,
+                );
+                setClientConfigValues({
+                  ...sClientConfigValues,
+                  [clientId]: {
+                    ...sClientConfigValues[clientId],
+                    [configKey]: newValue as string,
+                  },
+                });
+              }}
+            />
+          </React.Fragment>
+        );
+      })}
+
+      {/* Initial client settings, required and optional */}
+
+      {/* todo: option */}
+    </div>
+  );
+};
+
+export default InitialClientConfigs;

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -95,7 +95,6 @@ const InitialClientConfigs = ({
           }
         });
         const singleClientConfigValues = sClientConfigValues[clientId];
-        console.log('render conifgs: ', singleClientConfigValues);
         return (
           <React.Fragment key={clientId}>
             <DynamicSettings
@@ -109,12 +108,6 @@ const InitialClientConfigs = ({
               configValuesMap={singleClientConfigValues}
               isDisabled={false}
               onChange={(configKey: string, newValue: ConfigValue) => {
-                console.log(
-                  'initial client conifgs onChange: ',
-                  configKey,
-                  newValue,
-                  sClientConfigValues,
-                );
                 setClientConfigValues({
                   ...sClientConfigValues,
                   [clientId]: {

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { NodeSpecification } from '../../../common/nodeSpec';
 import DynamicSettings from '../../Generics/redesign/DynamicSettings/DynamicSettings';
 import {
+  ConfigTranslationAddNodeFlow,
   ConfigTranslationMap,
   ConfigValue,
   ConfigValuesMap,
@@ -19,11 +20,13 @@ export type ClientConfigTranslations = {
 
 export interface InitialClientConfigsProps {
   clientSpecs: NodeSpecification[];
+  addNodeFlowSelection: ConfigTranslationAddNodeFlow;
   onChange?: (newClientConfigValues: ClientConfigValues) => void;
 }
 
 const InitialClientConfigs = ({
   clientSpecs,
+  addNodeFlowSelection,
   onChange,
 }: InitialClientConfigsProps) => {
   const [sClientConfigValues, setClientConfigValues] =
@@ -87,7 +90,7 @@ const InitialClientConfigs = ({
         // Filter out only node config that is required for the add node flow
         Object.keys(singleClientConfigTranslation)?.map((configKey) => {
           const configTranslation = singleClientConfigTranslation[configKey];
-          if (configTranslation.addNodeFlow === 'required') {
+          if (configTranslation.addNodeFlow === addNodeFlowSelection) {
             requiredClientConfigTranslation[configKey] = configTranslation;
           }
         });

--- a/src/renderer/Presentational/AddNodeConfiguration/addNodeConfiguration.css.ts
+++ b/src/renderer/Presentational/AddNodeConfiguration/addNodeConfiguration.css.ts
@@ -28,3 +28,7 @@ export const sectionFont = style({
   fontWeight: 600,
   marginBottom: 0,
 });
+
+export const advancedOptionsLink = style({
+  marginTop: 16,
+});

--- a/src/renderer/Presentational/AddNodeConfiguration/deepMerge.ts
+++ b/src/renderer/Presentational/AddNodeConfiguration/deepMerge.ts
@@ -1,0 +1,197 @@
+/* eslint-disable no-nested-ternary */
+
+/**
+ * Raw code copied from https://github.com/voodoocreation/ts-deepmerge's index.ts file
+ * except for the mergeObjectReducer function and comments.
+ * We prefer to reduce npm dependencies when it is easy (ex. a single file)
+ *
+ * const obj1 = {
+  a: {
+    a: 1
+  }
+};
+
+const obj2 = {
+  b: {
+    a: 2,
+    b: 2
+  }
+};
+
+const obj3 = {
+  a: {
+    b: 3
+  },
+  b: {
+    b: 3,
+    c: 3
+  },
+  c: 3
+};
+
+const result = merge(obj1, obj2, obj3);
+
+returns {
+  "a": {
+    "a": 1,
+    "b": 3
+  },
+  "b": {
+    "a": 2,
+    "b": 3,
+    "c": 3
+  },
+  "c": 3
+}
+ */
+type TAllKeys<T> = T extends any ? keyof T : never;
+
+type TIndexValue<T, K extends PropertyKey, D = never> = T extends any
+  ? K extends keyof T
+    ? T[K]
+    : D
+  : never;
+
+type TPartialKeys<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>> extends infer O
+  ? { [P in keyof O]: O[P] }
+  : never;
+
+type TFunction = (...a: any[]) => any;
+
+type TPrimitives =
+  | string
+  | number
+  | boolean
+  | bigint
+  | symbol
+  | Date
+  | TFunction;
+
+type TMerged<T> = [T] extends [Array<any>]
+  ? { [K in keyof T]: TMerged<T[K]> }
+  : [T] extends [TPrimitives]
+  ? T
+  : [T] extends [object]
+  ? TPartialKeys<{ [K in TAllKeys<T>]: TMerged<TIndexValue<T, K>> }, never>
+  : T;
+
+// istanbul ignore next
+const isObject = (obj: any) => {
+  if (typeof obj === 'object' && obj !== null) {
+    if (typeof Object.getPrototypeOf === 'function') {
+      const prototype = Object.getPrototypeOf(obj);
+      return prototype === Object.prototype || prototype === null;
+    }
+
+    return Object.prototype.toString.call(obj) === '[object Object]';
+  }
+
+  return false;
+};
+
+interface IObject {
+  [key: string]: any;
+}
+
+const merge = <T extends IObject[]>(...objects: T): TMerged<T[number]> =>
+  objects.reduce((result, current) => {
+    if (Array.isArray(current)) {
+      throw new TypeError(
+        'Arguments provided to ts-deepmerge must be objects, not arrays.',
+      );
+    }
+
+    Object.keys(current).forEach((key) => {
+      if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+        return;
+      }
+
+      if (Array.isArray(result[key]) && Array.isArray(current[key])) {
+        result[key] = merge.options.mergeArrays
+          ? merge.options.uniqueArrayItems
+            ? Array.from(
+                new Set((result[key] as unknown[]).concat(current[key])),
+              )
+            : [...result[key], ...current[key]]
+          : current[key];
+      } else if (isObject(result[key]) && isObject(current[key])) {
+        result[key] = merge(result[key] as IObject, current[key] as IObject);
+      } else {
+        result[key] =
+          current[key] === undefined
+            ? merge.options.allowUndefinedOverrides
+              ? current[key]
+              : result[key]
+            : current[key];
+      }
+    });
+
+    return result;
+  }, {}) as any;
+
+interface IOptions {
+  /**
+   * When `true`, values explicitly provided as `undefined` will override existing values, though properties that are simply omitted won't affect anything.
+   * When `false`, values explicitly provided as `undefined` won't override existing values.
+   *
+   * Default: `true`
+   */
+  allowUndefinedOverrides: boolean;
+
+  /**
+   * When `true` it will merge array properties.
+   * When `false` it will replace array properties with the last instance entirely instead of merging their contents.
+   *
+   * Default: `true`
+   */
+  mergeArrays: boolean;
+
+  /**
+   * When `true` it will ensure there are no duplicate array items.
+   * When `false` it will allow duplicates when merging arrays.
+   *
+   * Default: `true`
+   */
+  uniqueArrayItems: boolean;
+}
+
+const defaultOptions: IOptions = {
+  allowUndefinedOverrides: true,
+  mergeArrays: true,
+  uniqueArrayItems: true,
+};
+
+merge.options = defaultOptions;
+
+merge.withOptions = <T extends IObject[]>(
+  options: Partial<IOptions>,
+  ...objects: T
+) => {
+  merge.options = {
+    ...defaultOptions,
+    ...options,
+  };
+
+  const result = merge(...objects);
+
+  merge.options = defaultOptions;
+
+  return result;
+};
+
+/**
+ * This does a deep merge on the action object with the previous state. This allows us to update
+ * any state property without having to provide the entire state object (some components don't have this when updating).
+ * This also helps with some closure/race conditions.
+ *
+ * See the comment at the top of deepMerge.ts for an detailed example.
+ * @param state object
+ * @param action object
+ * @returns object
+ */
+export const mergeObjectReducer = (state: object, action: object) => {
+  return merge(state, action);
+};
+
+export default merge;

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
@@ -28,6 +28,7 @@ import { NodePackageSpecification } from '../../../common/nodeSpec';
 import AddNodeConfiguration, {
   AddNodeConfigurationValues,
 } from '../AddNodeConfiguration/AddNodeConfiguration';
+import { nodeSpecIdLookupNum } from '../../events/environment';
 
 export interface AddNodeStepperProps {
   modal?: boolean;
@@ -169,7 +170,7 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
       { storageLocation: sNodeStorageLocation },
     );
     console.log('nodePackage result: ', nodePackage);
-    reportEvent('AddNodePackage');
+    reportEvent('AddNodePackage', nodeSpecIdLookupNum(nodePackageSpec.specId));
     dispatch(updateSelectedNodePackageId(nodePackage.id));
 
     electron.startNodePackage(nodePackage.id);

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
@@ -131,7 +131,7 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
       );
     }
     const services: AddNodePackageNodeService[] = [];
-    const { clientSelections } = sNodeClientsAndSettings;
+    const { clientSelections, clientConfigValues } = sNodeClientsAndSettings;
     if (sNodeLibrary && clientSelections) {
       // eslint-disable-next-line
       for (const [serviceId, selectOption] of Object.entries(
@@ -158,6 +158,7 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
           serviceId,
           serviceName: serviceDefinition?.name ?? serviceId,
           spec: serviceNodeSpec,
+          initialConfigValues: clientConfigValues?.[clientId],
         });
       }
     }

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
@@ -63,9 +63,11 @@ const AddNodeStepperModal = ({
     const config = {
       ...sEthereumNodeConfig,
       clientSelections: newValue.clientSelections,
+      clientConfigValues: newValue.clientConfigValues,
     };
     modalOnChangeConfig({
       clientSelections: newValue.clientSelections,
+      clientConfigValues: newValue.clientConfigValues,
     });
     setEthereumNodeConfig(config);
   };

--- a/src/renderer/Presentational/AddNodeStepper/mergeNodeRequirements.ts
+++ b/src/renderer/Presentational/AddNodeStepper/mergeNodeRequirements.ts
@@ -17,7 +17,7 @@ export const mergeSystemRequirements = (
     for (const [nodeReqKey, nodeReqValue] of Object.entries(
       systemRequirements,
     )) {
-      console.log(`${nodeReqKey}: ${nodeReqValue}`);
+      // console.log(`${nodeReqKey}: ${nodeReqValue}`);
       if (nodeReqKey === 'documentationUrl' || nodeReqKey === 'description') {
         // eslint-disable-next-line no-continue
         continue;

--- a/src/renderer/Presentational/ContentMultipleClients/ContentMultipleClients.tsx
+++ b/src/renderer/Presentational/ContentMultipleClients/ContentMultipleClients.tsx
@@ -75,9 +75,9 @@ const ContentMultipleClients = (props: {
   if (!clients) {
     return <></>;
   }
-  if (clients.length < 2) {
-    return <>No node found</>;
-  }
+  // if (clients.length < 1) {
+  //   return <>No node found</>;
+  // }
 
   const clClient = clients.find((client) => client.nodeType === 'consensus');
   const elClient = clients.find((client) => client.nodeType === 'execution');

--- a/src/renderer/Presentational/ContentMultipleClients/ContentMultipleClients.tsx
+++ b/src/renderer/Presentational/ContentMultipleClients/ContentMultipleClients.tsx
@@ -75,9 +75,9 @@ const ContentMultipleClients = (props: {
   if (!clients) {
     return <></>;
   }
-  // if (clients.length < 1) {
-  //   return <>No node found</>;
-  // }
+  if (clients.length < 1) {
+    return <>No node found</>;
+  }
 
   const clClient = clients.find((client) => client.nodeType === 'consensus');
   const elClient = clients.find((client) => client.nodeType === 'execution');
@@ -162,7 +162,6 @@ const ContentMultipleClients = (props: {
     //   };
     //   return nodeOverview;
     // }
-    // non-Ethereum node conditions added here
     if (!nodeContent) {
       return {};
     }

--- a/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
+++ b/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
@@ -8,11 +8,12 @@ import { Modal } from '../../Generics/redesign/Modal/Modal';
 import { modalOnChangeConfig, ModalConfig } from './modalUtils';
 import { useGetIsPodmanRunningQuery } from '../../state/settingsService';
 import { reportEvent } from '../../events/reportEvent';
-import {
-  NodePackageSpecification,
-  NodeSpecification,
-} from '../../../common/nodeSpec';
+import { NodePackageSpecification } from '../../../common/nodeSpec';
 import { AddNodePackageNodeService } from '../../../main/nodePackageManager';
+import {
+  NodeLibrary,
+  NodePackageLibrary,
+} from '../../../main/state/nodeLibrary';
 
 type Props = {
   modalOnClose: () => void;
@@ -20,17 +21,30 @@ type Props = {
 
 export const AddNodeModal = ({ modalOnClose }: Props) => {
   const [modalConfig, setModalConfig] = useState<ModalConfig>({});
-  const [sSelectedNodeSpec, setSelectedNodeSpec] =
-    useState<NodeSpecification>();
+  const [sSelectedNodePackageSpec, setSelectedNodePackageSpec] =
+    useState<NodePackageSpecification>();
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] =
     useState<boolean>(false);
   const [sIsPodmanRunning, setIsPodmanRunning] = useState<boolean>(false);
   const [step, setStep] = useState(0);
+  const [sNodeLibrary, setNodeLibrary] = useState<NodeLibrary>();
+  const [sNodePackageLibrary, setNodePackageLibrary] =
+    useState<NodePackageLibrary>();
   const { t } = useTranslation();
   const { t: g } = useTranslation('genericComponents');
 
+  useEffect(() => {}, []);
+
   useEffect(() => {
     reportEvent('OpenAddNodeModal');
+    const fetchNodeLibrarys = async () => {
+      const nodePackageLibrary: NodePackageLibrary =
+        await electron.getNodePackageLibrary();
+      setNodePackageLibrary(nodePackageLibrary);
+      const nodeLibrary: NodeLibrary = await electron.getNodeLibrary();
+      setNodeLibrary(nodeLibrary);
+    };
+    fetchNodeLibrarys();
   }, []);
 
   const qIsPodmanRunning = useGetIsPodmanRunningQuery(null, {
@@ -41,17 +55,15 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (
-      modalConfig?.node &&
-      modalConfig?.nodePackageLibrary?.[modalConfig.node]
-    ) {
-      setSelectedNodeSpec(modalConfig?.nodePackageLibrary?.[modalConfig.node]);
+    if (modalConfig?.node && sNodePackageLibrary?.[modalConfig.node]) {
+      setSelectedNodePackageSpec(sNodePackageLibrary?.[modalConfig.node]);
       console.log(
         'Node selected and node spec found: ',
-        modalConfig?.nodePackageLibrary?.[modalConfig.node],
+        sNodePackageLibrary?.[modalConfig.node],
       );
     }
-  }, [modalConfig]);
+    console.log('modalConfig useEffect. node', modalConfig.node);
+  }, [modalConfig, sNodePackageLibrary]);
 
   let modalTitle = '';
   switch (step) {
@@ -59,9 +71,9 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
       modalTitle = t('AddYourFirstNode');
       break;
     case 1:
-      if (sSelectedNodeSpec) {
+      if (sSelectedNodePackageSpec) {
         modalTitle = t('LaunchAVarNode', {
-          nodeName: sSelectedNodeSpec.displayName,
+          nodeName: sSelectedNodePackageSpec.displayName,
         });
       } else {
         modalTitle = t('LaunchAnEthereumNode');
@@ -83,14 +95,13 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
   const buttonSaveVariant = startNode ? 'icon-left' : 'text';
 
   const modalOnSaveConfig = async (updatedConfig: ModalConfig | undefined) => {
-    const {
-      node,
-      clientSelections,
-      clientConfigValues,
-      storageLocation,
-      nodeLibrary,
-      nodePackageLibrary,
-    } = updatedConfig || (modalConfig as ModalConfig);
+    const { node, clientSelections, clientConfigValues, storageLocation } =
+      updatedConfig || (modalConfig as ModalConfig);
+
+    // uses a state value because they were being overwritten by a bug
+    //  in modelConfig and updateModalConfig
+    const nodePackageLibrary = sNodePackageLibrary;
+    const nodeLibrary = sNodeLibrary;
 
     console.log('AddNodeModal modalOnSaveConfig(updatedConfig)', updatedConfig);
     // Mostly duplicate code with AddNodeStepper.addNodes()

--- a/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
+++ b/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
@@ -14,6 +14,7 @@ import {
   NodeLibrary,
   NodePackageLibrary,
 } from '../../../main/state/nodeLibrary';
+import { nodeSpecIdLookupNum } from '../../events/environment';
 
 type Props = {
   modalOnClose: () => void;
@@ -149,7 +150,7 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
       { storageLocation },
     );
     console.log('nodePackage result: ', nodePackage);
-    reportEvent('AddNodePackage');
+    reportEvent('AddNodePackage', nodeSpecIdLookupNum(nodePackageSpec.specId));
     dispatch(updateSelectedNodePackageId(nodePackage.id));
 
     electron.startNodePackage(nodePackage.id);

--- a/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
+++ b/src/renderer/Presentational/ModalManager/AddNodeModal.tsx
@@ -86,6 +86,7 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
     const {
       node,
       clientSelections,
+      clientConfigValues,
       storageLocation,
       nodeLibrary,
       nodePackageLibrary,
@@ -127,6 +128,7 @@ export const AddNodeModal = ({ modalOnClose }: Props) => {
           serviceId,
           serviceName: serviceDefinition?.name ?? serviceId,
           spec: serviceNodeSpec,
+          initialConfigValues: clientConfigValues?.[clientId],
         });
       }
     }

--- a/src/renderer/Presentational/ModalManager/modalUtils.tsx
+++ b/src/renderer/Presentational/ModalManager/modalUtils.tsx
@@ -6,8 +6,6 @@ import { ClientSelections } from '../AddNodeConfiguration/AddNodeConfiguration';
 
 export interface ModalConfig {
   node?: string;
-  executionClient?: string;
-  consensusClient?: string;
   clientSelections?: ClientSelections;
   storageLocation?: string;
   theme?: ThemeSetting;

--- a/src/renderer/Presentational/NodePackageScreen/NodePackageScreen.tsx
+++ b/src/renderer/Presentational/NodePackageScreen/NodePackageScreen.tsx
@@ -79,6 +79,8 @@ const NodePackageScreen = () => {
   if (qIsPodmanRunning && !qIsPodmanRunning.fetching) {
     isPodmanRunning = qIsPodmanRunning.data;
   }
+  // temporary until network is set at the node package level
+  const [sNetworkFromClients, setNetworkFromClients] = useState<string>('');
 
   // use to show if internet is disconnected
   // const qNetwork = useGetNetworkConnectedQuery(null, {
@@ -125,13 +127,7 @@ const NodePackageScreen = () => {
     if (typeof syncingData === 'object') {
       setSyncPercent(syncingData.syncPercent);
       setIsSyncing(syncingData.isSyncing);
-    }
-    // else if (syncingData === false) {
-    //   // light client geth, it is done syncing if data is false
-    //   setSyncPercent('');
-    //   setIsSyncing(false);
-    // }
-    else {
+    } else {
       setSyncPercent('');
       setIsSyncing(undefined);
     }
@@ -223,6 +219,7 @@ const NodePackageScreen = () => {
 
   useEffect(() => {
     // format for presentation
+    let guessNetworkFromClients = '';
     const formattedServices: ClientProps[] = [];
     selectedNodePackage?.services.map((service) => {
       const nodeId = service.node.id;
@@ -242,8 +239,14 @@ const NodePackageScreen = () => {
         stats: {},
       };
       formattedServices.push(serviceProps);
+
+      // temporary network parsing from client configs
+      if (node?.config?.configValuesMap?.network) {
+        guessNetworkFromClients = node?.config?.configValuesMap?.network;
+      }
     });
     setFormattedServices(formattedServices);
+    setNetworkFromClients(guessNetworkFromClients);
   }, [selectedNodePackage?.services, sUserNodes]);
 
   if (sHasSeenAlphaModal === false && !alphaModalRendered) {
@@ -292,13 +295,7 @@ const NodePackageScreen = () => {
     if (!info) {
       return '';
     }
-    if (info.includes('BeaconNode')) {
-      return 'Consensus Client — Ethereum Mainnet';
-    }
-    if (info.includes('Execution')) {
-      return 'Execution Client — Ethereum Mainnet';
-    }
-    return info;
+    return `${info} ${sNetworkFromClients}`;
   };
 
   const formatVersion = (version: string | undefined, name: string) => {

--- a/src/renderer/Presentational/NodeScreen/NodeScreen.tsx
+++ b/src/renderer/Presentational/NodeScreen/NodeScreen.tsx
@@ -287,15 +287,15 @@ const NodeScreen = () => {
   const { status, spec } = selectedNode;
 
   // TODO: make this more flexible for other client specs
-  const formatSpec = (info: string | undefined) => {
+  const formatSpec = (info: string | undefined, network?: string) => {
     if (!info) {
       return '';
     }
     if (info.includes('BeaconNode')) {
-      return 'Consensus Client — Ethereum Mainnet';
+      return `Consensus Client — Ethereum ${network}`;
     }
     if (info.includes('Execution')) {
-      return 'Execution Client — Ethereum Mainnet';
+      return `Execution Client — Ethereum ${network}`;
     }
     return info;
   };
@@ -364,7 +364,10 @@ const NodeScreen = () => {
     screenType: 'client',
     rpcTranslation: spec.rpcTranslation,
     version: formatVersion(nodeVersionData, clientName),
-    info: formatSpec(spec.category),
+    info: formatSpec(
+      spec.category,
+      selectedNode?.config?.configValuesMap?.network,
+    ),
     status: {
       stopped: status === 'stopped',
       error: status.includes('error'),

--- a/src/renderer/Presentational/SidebarWrapper/SidebarWrapper.tsx
+++ b/src/renderer/Presentational/SidebarWrapper/SidebarWrapper.tsx
@@ -39,7 +39,6 @@ export const SidebarWrapper = forwardRef<HTMLDivElement>((_, ref) => {
     // Only polls network connection if there are exactly 0 peers
     pollingInterval: 30000,
   });
-  console.log('qNetwork', qNetwork);
   const [platform, setPlatform] = useState<string>('');
   // default to docker is running while data is being fetched, so
   //  the user isn't falsely warned

--- a/src/renderer/assets/images/nodeBackgrounds/index.tsx
+++ b/src/renderer/assets/images/nodeBackgrounds/index.tsx
@@ -42,7 +42,7 @@ export const NODE_BACKGROUNDS: NodeBackgrounds = {
   nimbus,
   'op-geth': geth,
   'op-node': nimbus,
-  hubble: geth,
+  hubble: lighthouse,
 };
 
 export type NodeBackgroundId = keyof NodeBackgrounds;

--- a/src/renderer/assets/images/nodeBackgrounds/index.tsx
+++ b/src/renderer/assets/images/nodeBackgrounds/index.tsx
@@ -26,6 +26,7 @@ export interface NodeBackgrounds {
   'op-geth'?: string;
   'op-node'?: string;
   hubble?: string;
+  nitro?: string;
 }
 
 // Define all icons here
@@ -43,6 +44,7 @@ export const NODE_BACKGROUNDS: NodeBackgrounds = {
   'op-geth': geth,
   'op-node': nimbus,
   hubble: lighthouse,
+  nitro: teku,
 };
 
 export type NodeBackgroundId = keyof NodeBackgrounds;

--- a/src/renderer/assets/images/nodeBackgrounds/index.tsx
+++ b/src/renderer/assets/images/nodeBackgrounds/index.tsx
@@ -25,6 +25,7 @@ export interface NodeBackgrounds {
   nimbus?: string;
   'op-geth'?: string;
   'op-node'?: string;
+  hubble?: string;
 }
 
 // Define all icons here
@@ -41,6 +42,7 @@ export const NODE_BACKGROUNDS: NodeBackgrounds = {
   nimbus,
   'op-geth': geth,
   'op-node': nimbus,
+  hubble: geth,
 };
 
 export type NodeBackgroundId = keyof NodeBackgrounds;

--- a/src/renderer/assets/images/nodeIcons/index.tsx
+++ b/src/renderer/assets/images/nodeIcons/index.tsx
@@ -56,6 +56,7 @@ export interface NodeIcons {
   ['op-node']?: string;
   farcaster?: string;
   hubble?: string;
+  nitro?: string;
 }
 
 // Define all icons here
@@ -87,6 +88,7 @@ export const NODE_ICONS: NodeIcons = {
   'op-node': optimism,
   farcaster,
   hubble: farcaster,
+  nitro: arbitrum,
 };
 
 const white = '#FFFFFF';

--- a/src/renderer/events/environment.ts
+++ b/src/renderer/events/environment.ts
@@ -1,4 +1,5 @@
 /* eslint-disable prefer-destructuring */
+import { NodeId } from 'common/node';
 import { NNEvent } from './events';
 
 // declares the type of the injected variable process from webpack plugin
@@ -46,4 +47,17 @@ export const eventIdLookup = (event: NNEvent): string => {
   let eventId = '';
   eventId = envEvent[FATHOM_SITE_ENV][event];
   return eventId;
+};
+
+const nodeNumber: Record<NodeId, number> = {
+  ethereum: 2,
+  farcaster: 3,
+  arbitrum: 4,
+  base: 5,
+  optimism: 6,
+};
+
+export const nodeSpecIdLookupNum = (nodeId: NodeId): number => {
+  const nodeNum = nodeNumber[nodeId] ?? 1;
+  return nodeNum;
 };

--- a/src/renderer/events/reportEvent.ts
+++ b/src/renderer/events/reportEvent.ts
@@ -29,10 +29,10 @@ export const setRemoteEventReportingEnabled = (isEnabled: boolean) => {
  * logged or optionally sent to tracking service for core contributors to review.
  * @param event
  */
-export const reportEvent = (event: NNEvent) => {
-  console.log('reportEvent: ', event);
+export const reportEvent = (event: NNEvent, value?: number) => {
+  console.log('reportEvent, value: ', event, value);
   const eventId = eventIdLookup(event);
-  Fathom.trackGoal(eventId, 1);
+  Fathom.trackGoal(eventId, value !== undefined ? value : 0);
 };
 
 export const initialize = () => {

--- a/src/renderer/state/rpcExecuteTranslation.ts
+++ b/src/renderer/state/rpcExecuteTranslation.ts
@@ -133,9 +133,22 @@ export const executeTranslation = async (
       }
     } else if (rpcCall === 'clientVersion') {
       const resp = await callFetch(`${beaconBaseUrl}/eth/v1/node/version`);
-      console.log('peers fetch resp ', resp);
       if (resp?.data?.version !== undefined) {
         return resp.data.version;
+      }
+    }
+  } else if (rpcTranslation === 'farcaster-l1') {
+    // todo: use the current config httpPort value instead of hardcoding 2281
+    const hubbleBaseUrl = 'http://localhost:2281';
+    if (rpcCall === 'sync') {
+      const resp = await callFetch(`${hubbleBaseUrl}/v1/info`);
+      if (resp?.isSyncing !== undefined) {
+        return { isSyncing: resp.isSyncing };
+      }
+    } else if (rpcCall === 'clientVersion') {
+      const resp = await callFetch(`${hubbleBaseUrl}/v1/info`);
+      if (resp?.version !== undefined) {
+        return `v${resp.version}`;
       }
     }
   } else if (rpcTranslation === 'eth-l2-starknet') {

--- a/src/renderer/state/rpcExecuteTranslation.ts
+++ b/src/renderer/state/rpcExecuteTranslation.ts
@@ -48,9 +48,9 @@ const callFetch = async (apiRoute: string) => {
 };
 
 const provider = new ethers.providers.JsonRpcProvider('http://localhost:8545');
-// const arbProvider = new ethers.providers.JsonRpcProvider(
-//   'http://localhost:8547'
-// );
+const ethL2Provider = new ethers.providers.JsonRpcProvider(
+  'http://localhost:8547',
+);
 
 // const provider9545 = new ethers.providers.JsonRpcProvider(
 //   'http://localhost:9545'
@@ -94,6 +94,44 @@ export const executeTranslation = async (
       return resp;
     } else if (rpcCall === 'clientVersion') {
       const resp = await provider.send('web3_clientVersion');
+      if (resp) {
+        return resp;
+      } else {
+        return undefined;
+      }
+    }
+  } else if (rpcTranslation === 'eth-l2') {
+    // use ethL2Provider
+    if (rpcCall === 'sync') {
+      const resp = await ethL2Provider.send('eth_syncing');
+      let isSyncing;
+      let syncPercent;
+      if (resp) {
+        if (typeof resp === 'object') {
+          const syncRatio = resp.currentBlock / resp.highestBlock;
+          syncPercent = (syncRatio * 100).toFixed(1);
+          isSyncing = true;
+        } else if (resp === false) {
+          // light client geth, it is done syncing if data is false
+          isSyncing = false;
+        }
+      }
+      return { isSyncing, syncPercent };
+    } else if (rpcCall === 'peers') {
+      const resp = await ethL2Provider.send('net_peerCount');
+      if (resp) {
+        return hexToDecimal(resp);
+      } else {
+        return undefined;
+      }
+    } else if (rpcCall === 'latestBlock') {
+      const resp = await ethL2Provider.send('eth_getBlockByNumber', [
+        'latest',
+        true,
+      ]);
+      return resp;
+    } else if (rpcCall === 'clientVersion') {
+      const resp = await ethL2Provider.send('web3_clientVersion');
       if (resp) {
         return resp;
       } else {

--- a/src/stories/Generic/LabelSettings.stories.tsx
+++ b/src/stories/Generic/LabelSettings.stories.tsx
@@ -4,6 +4,7 @@ import LabelSettings from '../../renderer/Generics/redesign/LabelSetting/LabelSe
 import ExternalLink from '../../renderer/Generics/redesign/Link/ExternalLink';
 import Select from '../../renderer/Generics/redesign/Select/Select';
 import { Toggle } from '../../renderer/Generics/redesign/Toggle/Toggle';
+import Input from '../../renderer/Generics/redesign/Input/Input';
 
 export default {
   title: 'Generic/LabelSettings',
@@ -22,6 +23,11 @@ About.args = {
     {
       sectionTitle: 'Preferences',
       items: [
+        {
+          label: 'Ethereum RPC Endpoint',
+          value: <Input value={'http://localhost:8545'} disabled={false} />,
+          learnMoreLink: 'https://nicenode.xyz',
+        },
         {
           label: 'Launch on startup',
           value: <Toggle checked={true} />,


### PR DESCRIPTION
https://github.com/NiceNode/nice-node/assets/3721291/3dd0e554-f61f-478a-9002-cc0ba4a5064e

https://github.com/NiceNode/nice-node/assets/3721291/f808fa61-e174-4fc1-8b18-8d79606c0758



- Required and advanced node settings in the add node flow as dictated by the `addNodeFlow='required'|'advanced'` value in the node specification config object
- Initialize node command support - this runs one command before starting the node for the first time (hubble and op stack nodes require this)
- Farcaster Hubble support (tested on mac and linux)
- Hubble version and isSyncing values work 3 minutes or so after starting Hubble (filed issue on repo)
- Arbitrum nitro node is mostly working (filed issue on repo), still no api support (filed issue on repo)
- reporting AddNodePackage event can include a value indicating the node package added

known bugs
- initial node settings: input is on one line, but designs have the input description above the input
- double horizontal line below required input
- irrelevant header metrics for non eth-nodes