### PR TITLE
Feat: Copy Functionality for Logs

### DIFF
--- a/src/renderer/Generics/redesign/FloatingButton/FloatingButton.tsx
+++ b/src/renderer/Generics/redesign/FloatingButton/FloatingButton.tsx
@@ -24,10 +24,11 @@ const FloatingButton = ({
   label,
   ...props
 }: FloatingButtonProps) => {
+  const addBaseButton = iconId !== 'copy';
   return (
     <button
       type="button"
-      className={[baseButton, variant].join(' ')}
+      className={[addBaseButton ? baseButton : '', variant].join(' ')}
       {...props}
     >
       {variant !== 'icon' && (

--- a/src/renderer/Generics/redesign/FloatingButton/FloatingButton.tsx
+++ b/src/renderer/Generics/redesign/FloatingButton/FloatingButton.tsx
@@ -1,6 +1,11 @@
 import { IconId } from 'renderer/assets/images/icons';
 import { Icon } from '../Icon/Icon';
-import { baseButton, iconLeft, iconStyle } from './floatingButton.css';
+import {
+  baseButton,
+  copyIcon,
+  iconLeft,
+  iconStyle,
+} from './floatingButton.css';
 
 export interface FloatingButtonProps {
   /**
@@ -24,11 +29,11 @@ const FloatingButton = ({
   label,
   ...props
 }: FloatingButtonProps) => {
-  const addBaseButton = iconId !== 'copy';
+  const additionalClass = iconId === 'copy' ? copyIcon : '';
   return (
     <button
       type="button"
-      className={[addBaseButton ? baseButton : '', variant].join(' ')}
+      className={[baseButton, variant, additionalClass].join(' ')}
       {...props}
     >
       {variant !== 'icon' && (

--- a/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
+++ b/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
@@ -46,11 +46,17 @@ export const copyIcon = style({
   width: 3,
   height: 3,
   top: -5,
+  left: '-20px',
   color: vars.color.font70,
-  background: 'transparent',
+  // no opacity desired here, so using background with alpha=1
+  background: vars.color.background,
   selectors: {
+    // follows secondary button
     '&:hover:enabled': {
-      background: vars.color.background92,
+      background: vars.color.backgroundHoverGradient,
+    },
+    '&:active:enabled': {
+      background: vars.color.backgroundActiveGradient,
     },
   },
   borderRadius: 5,

--- a/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
+++ b/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
@@ -40,3 +40,10 @@ export const iconStyle = style({
   width: 16,
   height: 16,
 });
+
+export const copyIcon = style({
+  bottom: 0,
+  width: 4,
+  height: 4,
+  top: 2,
+});

--- a/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
+++ b/src/renderer/Generics/redesign/FloatingButton/floatingButton.css.ts
@@ -43,7 +43,16 @@ export const iconStyle = style({
 
 export const copyIcon = style({
   bottom: 0,
-  width: 4,
-  height: 4,
-  top: 2,
+  width: 3,
+  height: 3,
+  top: -5,
+  color: vars.color.font70,
+  background: 'transparent',
+  selectors: {
+    '&:hover:enabled': {
+      background: vars.color.background92,
+    },
+  },
+  borderRadius: 5,
+  padding: '10px 12px',
 });

--- a/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
+++ b/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
@@ -4,6 +4,7 @@ import {
   timestampStyle,
   levelStyle,
   messageStyle,
+  copyStyle,
 } from './logMessage.css';
 import FloatingButton from '../FloatingButton/FloatingButton';
 
@@ -32,7 +33,9 @@ export const LogMessage = ({ timestamp, level, message }: LogMessageProps) => {
       </div>
       <div className={[levelStyle, `${level}`].join(' ')}>{level}</div>
       <div className={messageStyle}>{message}</div>
-      <FloatingButton variant="icon" iconId="copy" />
+      <div className={copyStyle}>
+        <FloatingButton variant="icon" iconId="copy" />
+      </div>
     </div>
   );
 };

--- a/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
+++ b/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
@@ -24,6 +24,10 @@ export interface LogMessageProps {
 }
 
 export const LogMessage = ({ timestamp, level, message }: LogMessageProps) => {
+  const copy = async () => {
+    await navigator.clipboard.writeText(message);
+  };
+
   return (
     <div className={container}>
       <div className={timestampStyle}>
@@ -34,7 +38,7 @@ export const LogMessage = ({ timestamp, level, message }: LogMessageProps) => {
       <div className={[levelStyle, `${level}`].join(' ')}>{level}</div>
       <div className={messageStyle}>{message}</div>
       <div className={copyStyle}>
-        <FloatingButton variant="icon" iconId="copy" />
+        <FloatingButton variant="icon" iconId="copy" onClick={copy} />
       </div>
     </div>
   );

--- a/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
+++ b/src/renderer/Generics/redesign/LogMessage/LogMessage.tsx
@@ -5,6 +5,7 @@ import {
   levelStyle,
   messageStyle,
 } from './logMessage.css';
+import FloatingButton from '../FloatingButton/FloatingButton';
 
 export interface LogMessageProps {
   /**
@@ -31,6 +32,7 @@ export const LogMessage = ({ timestamp, level, message }: LogMessageProps) => {
       </div>
       <div className={[levelStyle, `${level}`].join(' ')}>{level}</div>
       <div className={messageStyle}>{message}</div>
+      <FloatingButton variant="icon" iconId="copy" />
     </div>
   );
 };

--- a/src/renderer/Generics/redesign/LogMessage/logMessage.css.ts
+++ b/src/renderer/Generics/redesign/LogMessage/logMessage.css.ts
@@ -4,6 +4,7 @@ import { vars, common } from '../theme.css';
 export const container = style({
   boxSizing: 'border-box',
   display: 'flex',
+  position: 'relative',
   flexDirection: 'row',
   alignItems: 'flex-start',
   padding: '4px 0px',
@@ -56,4 +57,15 @@ export const messageStyle = style({
   order: 3,
   flexGrow: 1,
   overflowWrap: 'anywhere',
+});
+
+export const copyStyle = style({
+  display: 'none',
+  position: 'absolute',
+  selectors: {
+    [`${container}:hover &`]: {
+      display: 'block',
+      right: 0,
+    },
+  },
 });

--- a/src/stories/Generic/LogMessage.stories.tsx
+++ b/src/stories/Generic/LogMessage.stories.tsx
@@ -1,0 +1,70 @@
+import { Story, Meta } from '@storybook/react';
+import {
+  LogMessage,
+  LogMessageProps,
+} from '../../renderer/Generics/redesign/LogMessage/LogMessage';
+import FloatingButton from '../../renderer/Generics/redesign/FloatingButton/FloatingButton';
+
+export default {
+  title: 'Generic/LogMessage',
+  component: LogMessage,
+} as Meta;
+
+const Template: Story<LogMessageProps> = (args) => <LogMessage {...args} />;
+
+export const InfoMessage = Template.bind({});
+InfoMessage.args = {
+  timestamp: Date.now(),
+  level: 'INFO',
+  message: 'This is an info message',
+};
+
+export const WarningMessage = Template.bind({});
+WarningMessage.args = {
+  timestamp: Date.now(),
+  level: 'WARNING',
+  message: 'This is a warning message',
+};
+
+export const ErrorMessage = Template.bind({});
+ErrorMessage.args = {
+  timestamp: Date.now(),
+  level: 'ERROR',
+  message: 'This is an error message',
+};
+
+export const CustomTimestamp = Template.bind({});
+CustomTimestamp.args = {
+  timestamp: Date.now(),
+  level: 'CUSTOM',
+  message: 'This is a message with a custom timestamp',
+};
+
+export const LongMessage = Template.bind({});
+LongMessage.args = {
+  timestamp: Date.now(),
+  level: 'INFO',
+  message:
+    'This is a very long message that extends beyond the typical message size. It should wrap and display properly within the component.',
+};
+
+export const WithFloatingButton = Template.bind({});
+WithFloatingButton.args = {
+  timestamp: Date.now(),
+  level: 'INFO',
+  message: 'This message includes a FloatingButton',
+};
+WithFloatingButton.decorators = [
+  (Story) => (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <Story />
+      <div style={{ marginLeft: '10px' }}>
+        <FloatingButton
+          variant="icon"
+          iconId="copy"
+          onClick={() => alert('Button Clicked')}
+        />
+      </div>
+    </div>
+  ),
+];


### PR DESCRIPTION
# Implementation

Fully functional copy button for copying a specific log details along with storybook creating for <LogMessage /> Component

![Screenshot_20231015_235726](https://github.com/NiceNode/nice-node/assets/94786511/cc62e024-9f03-4264-bfeb-f903b9a29bc5)

![Screenshot_20231015_235759](https://github.com/NiceNode/nice-node/assets/94786511/a1482016-a195-41a2-89af-26f1d2830e52)

![Screenshot_20231016_000939](https://github.com/NiceNode/nice-node/assets/94786511/1139cb49-0919-479b-8ac4-c578a37e4d96)


## Requirement checklist
 - [x] the button should only show if the user is hovering over that specific log line
 - [x] clicking the copy button should copy the log to the "clipboard" and work on Mac, Win, Linux
 - [x] bonus: create a storybook story for the <LogMessage /> component to show and test the component without rendering the entire app and running podman and a node. use npm run storybook to test


## Related issue 

#319 
