### PR TITLE
chore: bump op-node 1.7.1

### DIFF
--- a/src/common/NodeSpecs/op-node/op-node-v1.0.0.json
+++ b/src/common/NodeSpecs/op-node/op-node-v1.0.0.json
@@ -21,7 +21,7 @@
         "forcedRawNodeInput": "op-node --syncmode=execution-layer --rpc.addr 0.0.0.0 --l2.jwt-secret /root/.ethereum/jwtsecret"
       }
     },
-    "imageName": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.0"
+    "imageName": "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.1"
   },
   "category": "L2/ConsensusClient",
   "rpcTranslation": "eth-l2-consensus",


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.7.1
