### PR TITLE
chore: change p2p port for op-geth to default

### DIFF
--- a/src/common/NodeSpecs/op-geth/op-geth-v1.0.0.json
+++ b/src/common/NodeSpecs/op-geth/op-geth-v1.0.0.json
@@ -11,6 +11,7 @@
         "http": "Enabled",
         "httpPort": "8547",
         "enginePort": "8553",
+        "p2pPorts": "39393",
         "httpCorsDomains": "http://localhost",
         "webSockets": "Disabled",
         "httpVirtualHosts": "localhost,host.containers.internal",
@@ -121,8 +122,8 @@
       "uiControl": {
         "type": "text"
       },
-      "infoDescription": "Example value: 30303",
-      "defaultValue": "30303"
+      "infoDescription": "Example value: 39393",
+      "defaultValue": "39393"
     },
     "httpApis": {
       "displayName": "Enabled HTTP APIs",


### PR DESCRIPTION
Docs for p2p port default change from 30303: https://github.com/smartcontracts/simple-optimism-node/releases/tag/v1.7.1?notification_referrer_id=NT_kwDOADjIS7I5ODA5NzA2MzA4OjM3MjEyOTE