### PR TITLE
fix: improper reth volume path

### DIFF
--- a/src/common/NodeSpecs/reth/reth-v1.0.0.json
+++ b/src/common/NodeSpecs/reth/reth-v1.0.0.json
@@ -17,9 +17,9 @@
         "webSocketAllowedOrigins": "http://localhost"
       },
       "docker": {
-        "containerVolumePath": "/root/.local/share/reth/mainnet/db",
+        "containerVolumePath": "/root/.local/share/reth/mainnet",
         "raw": "",
-        "forcedRawNodeInput": "node --color never --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /root/.local/share/reth/mainnet/db/jwtsecret --ipcdisable"
+        "forcedRawNodeInput": "node --color never --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /root/.local/share/reth/mainnet/jwtsecret --ipcdisable"
       }
     },
     "imageName": "ghcr.io/paradigmxyz/reth",


### PR DESCRIPTION
I encountered an issue paradigmxyz/reth#7263 when running the reth node with NiceNode, and this issue was resolved through paradigmxyz/reth#7590.

To reproduce the issue, you can try stopping the reth node and then resuming its operation.

![telegram-cloud-document-1-4958573402890699840](https://github.com/NiceNode/nice-node/assets/36319157/5680cc4f-3508-4c64-8e5f-3db47a0029f3)

![telegram-cloud-document-1-4958573402890699841](https://github.com/NiceNode/nice-node/assets/36319157/ee9699b4-1d8f-4810-8d83-ff199b0d7eff)
