### PR TITLE
fix: set node last seen running time every hour

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -251,6 +251,7 @@ app.on('activate', () => {
 const onExit = () => {
   onExitNodeManager();
   monitor.onExit();
+  cronJobs.onExit();
   app.quit(); // todo: remove
 };
 


### PR DESCRIPTION
This fixes the last running timestamp being outdated. Without this change, it only gets set after starting a node which means if a user starts a node, leaves it running, it won't get updated, and it won't be included as an "active" node at https://impact.nicenode.xyz/