### PR TITLE
Feat: Direct command line settings

### DIFF
--- a/src/main/nodeLibraryManager.ts
+++ b/src/main/nodeLibraryManager.ts
@@ -1,51 +1,51 @@
-import arbitrumv1 from "../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json";
-import basev1 from "../common/NodeSpecs/base/base-v1.0.0.json";
+import arbitrumv1 from '../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json';
+import basev1 from '../common/NodeSpecs/base/base-v1.0.0.json';
 // Node Packages
-import ethereumv1 from "../common/NodeSpecs/ethereum/ethereum-v1.0.0.json";
-import farcasterv1 from "../common/NodeSpecs/farcaster/farcaster-v1.0.0.json";
-import homeAssistantv1 from "../common/NodeSpecs/home-assistant/home-assistant-v1.0.0.json";
-import minecraftv1 from "../common/NodeSpecs/minecraft/minecraft-v1.0.0.json";
-import optimismv1 from "../common/NodeSpecs/optimism/optimism-v1.0.0.json";
+import ethereumv1 from '../common/NodeSpecs/ethereum/ethereum-v1.0.0.json';
+import farcasterv1 from '../common/NodeSpecs/farcaster/farcaster-v1.0.0.json';
+import homeAssistantv1 from '../common/NodeSpecs/home-assistant/home-assistant-v1.0.0.json';
+import minecraftv1 from '../common/NodeSpecs/minecraft/minecraft-v1.0.0.json';
+import optimismv1 from '../common/NodeSpecs/optimism/optimism-v1.0.0.json';
 
 // Node Services
-import besuv1 from "../common/NodeSpecs/besu/besu-v1.0.0.json";
-import erigonv1 from "../common/NodeSpecs/erigon/erigon-v1.0.0.json";
-import gethv1 from "../common/NodeSpecs/geth/geth-v1.0.0.json";
-import nethermindv1 from "../common/NodeSpecs/nethermind/nethermind-v1.0.0.json";
-import rethv1 from "../common/NodeSpecs/reth/reth-v1.0.0.json";
+import besuv1 from '../common/NodeSpecs/besu/besu-v1.0.0.json';
+import erigonv1 from '../common/NodeSpecs/erigon/erigon-v1.0.0.json';
+import gethv1 from '../common/NodeSpecs/geth/geth-v1.0.0.json';
+import nethermindv1 from '../common/NodeSpecs/nethermind/nethermind-v1.0.0.json';
+import rethv1 from '../common/NodeSpecs/reth/reth-v1.0.0.json';
 
-import lighthousev1 from "../common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json";
-import lodestarv1 from "../common/NodeSpecs/lodestar/lodestar-v1.0.0.json";
-import nimbusv1 from "../common/NodeSpecs/nimbus/nimbus-v1.0.0.json";
-import prysmv1 from "../common/NodeSpecs/prysm/prysm-v1.0.0.json";
-import tekuv1 from "../common/NodeSpecs/teku/teku-v1.0.0.json";
+import lighthousev1 from '../common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json';
+import lodestarv1 from '../common/NodeSpecs/lodestar/lodestar-v1.0.0.json';
+import nimbusv1 from '../common/NodeSpecs/nimbus/nimbus-v1.0.0.json';
+import prysmv1 from '../common/NodeSpecs/prysm/prysm-v1.0.0.json';
+import tekuv1 from '../common/NodeSpecs/teku/teku-v1.0.0.json';
 
-import pathfinderv1 from "../common/NodeSpecs/pathfinder/pathfinder-v1.0.0.json";
+import pathfinderv1 from '../common/NodeSpecs/pathfinder/pathfinder-v1.0.0.json';
 
-import hildrv1 from "../common/NodeSpecs/hildr/hildr-v1.0.0.json";
-import magiv1 from "../common/NodeSpecs/magi/magi-v1.0.0.json";
-import opGethv1 from "../common/NodeSpecs/op-geth/op-geth-v1.0.0.json";
-import opNodev1 from "../common/NodeSpecs/op-node/op-node-v1.0.0.json";
+import hildrv1 from '../common/NodeSpecs/hildr/hildr-v1.0.0.json';
+import magiv1 from '../common/NodeSpecs/magi/magi-v1.0.0.json';
+import opGethv1 from '../common/NodeSpecs/op-geth/op-geth-v1.0.0.json';
+import opNodev1 from '../common/NodeSpecs/op-node/op-node-v1.0.0.json';
 
-import hubblev1 from "../common/NodeSpecs/hubble/hubble-v1.0.0.json";
+import hubblev1 from '../common/NodeSpecs/hubble/hubble-v1.0.0.json';
 
-import nitrov1 from "../common/NodeSpecs/nitro/nitro-v1.0.0.json";
+import nitrov1 from '../common/NodeSpecs/nitro/nitro-v1.0.0.json';
 
-import homeAssistantServicev1 from "../common/NodeSpecs/home-assistant-service/home-assistant-service-v1.0.0.json";
-import itzgMinecraftv1 from "../common/NodeSpecs/itzg-minecraft/itzg-minecraft-v1.0.0.json";
+import homeAssistantServicev1 from '../common/NodeSpecs/home-assistant-service/home-assistant-service-v1.0.0.json';
+import itzgMinecraftv1 from '../common/NodeSpecs/itzg-minecraft/itzg-minecraft-v1.0.0.json';
 
 import type {
   NodePackageSpecification,
   NodeSpecification,
   DockerExecution as PodmanExecution,
-} from "../common/nodeSpec";
-import logger from "./logger";
+} from '../common/nodeSpec';
+import logger from './logger';
 import {
   type NodeLibrary,
   type NodePackageLibrary,
   updateNodeLibrary,
   updateNodePackageLibrary,
-} from "./state/nodeLibrary";
+} from './state/nodeLibrary';
 
 export const initialize = async () => {
   // parse spec json for latest versions
@@ -81,9 +81,9 @@ export const initialize = async () => {
         nodeSpec.configTranslation = {};
       }
 
-      // "inject" serviceVersion and dataDir (todo) here. Universal for all nodes.
+      // 'inject' serviceVersion and dataDir (todo) here. Universal for all nodes.
       const execution = nodeSpec.execution as PodmanExecution;
-      let defaultImageTag = "latest";
+      let defaultImageTag = 'latest';
       // if the defaultImageTag is set in the spec use that, otherwise 'latest'
       if (execution.defaultImageTag !== undefined) {
         defaultImageTag = execution.defaultImageTag;
@@ -92,23 +92,23 @@ export const initialize = async () => {
       nodeSpec.configTranslation.cliInput = {
         displayName: `${spec.displayName} CLI Input`,
         uiControl: {
-          type: "text",
+          type: 'text',
         },
-        defaultValue: "",
-        addNodeFlow: "advanced",
+        defaultValue: ',
+        addNodeFlow: 'advanced',
         infoDescription:
-          "Enter any direct CLI input to the node start command.",
+          'Enter any direct CLI input to the node start command.',
       };
 
       nodeSpec.configTranslation.serviceVersion = {
         displayName: `${spec.displayName} version`,
         uiControl: {
-          type: "text",
+          type: 'text',
         },
         defaultValue: defaultImageTag,
-        addNodeFlow: "advanced",
+        addNodeFlow: 'advanced',
         infoDescription:
-          "Caution Advised! Example value: latest, v1.0.0, stable. Consult service documentation for available versions.",
+          'Caution Advised! Example value: latest, v1.0.0, stable. Consult service documentation for available versions.',
       };
 
       nodeSpecBySpecId[spec.specId] = nodeSpec;

--- a/src/main/nodeLibraryManager.ts
+++ b/src/main/nodeLibraryManager.ts
@@ -1,51 +1,51 @@
-import arbitrumv1 from '../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json';
-import basev1 from '../common/NodeSpecs/base/base-v1.0.0.json';
+import arbitrumv1 from "../common/NodeSpecs/arbitrum/arbitrum-v1.0.0.json";
+import basev1 from "../common/NodeSpecs/base/base-v1.0.0.json";
 // Node Packages
-import ethereumv1 from '../common/NodeSpecs/ethereum/ethereum-v1.0.0.json';
-import farcasterv1 from '../common/NodeSpecs/farcaster/farcaster-v1.0.0.json';
-import homeAssistantv1 from '../common/NodeSpecs/home-assistant/home-assistant-v1.0.0.json';
-import minecraftv1 from '../common/NodeSpecs/minecraft/minecraft-v1.0.0.json';
-import optimismv1 from '../common/NodeSpecs/optimism/optimism-v1.0.0.json';
+import ethereumv1 from "../common/NodeSpecs/ethereum/ethereum-v1.0.0.json";
+import farcasterv1 from "../common/NodeSpecs/farcaster/farcaster-v1.0.0.json";
+import homeAssistantv1 from "../common/NodeSpecs/home-assistant/home-assistant-v1.0.0.json";
+import minecraftv1 from "../common/NodeSpecs/minecraft/minecraft-v1.0.0.json";
+import optimismv1 from "../common/NodeSpecs/optimism/optimism-v1.0.0.json";
 
 // Node Services
-import besuv1 from '../common/NodeSpecs/besu/besu-v1.0.0.json';
-import erigonv1 from '../common/NodeSpecs/erigon/erigon-v1.0.0.json';
-import gethv1 from '../common/NodeSpecs/geth/geth-v1.0.0.json';
-import nethermindv1 from '../common/NodeSpecs/nethermind/nethermind-v1.0.0.json';
-import rethv1 from '../common/NodeSpecs/reth/reth-v1.0.0.json';
+import besuv1 from "../common/NodeSpecs/besu/besu-v1.0.0.json";
+import erigonv1 from "../common/NodeSpecs/erigon/erigon-v1.0.0.json";
+import gethv1 from "../common/NodeSpecs/geth/geth-v1.0.0.json";
+import nethermindv1 from "../common/NodeSpecs/nethermind/nethermind-v1.0.0.json";
+import rethv1 from "../common/NodeSpecs/reth/reth-v1.0.0.json";
 
-import lighthousev1 from '../common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json';
-import lodestarv1 from '../common/NodeSpecs/lodestar/lodestar-v1.0.0.json';
-import nimbusv1 from '../common/NodeSpecs/nimbus/nimbus-v1.0.0.json';
-import prysmv1 from '../common/NodeSpecs/prysm/prysm-v1.0.0.json';
-import tekuv1 from '../common/NodeSpecs/teku/teku-v1.0.0.json';
+import lighthousev1 from "../common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json";
+import lodestarv1 from "../common/NodeSpecs/lodestar/lodestar-v1.0.0.json";
+import nimbusv1 from "../common/NodeSpecs/nimbus/nimbus-v1.0.0.json";
+import prysmv1 from "../common/NodeSpecs/prysm/prysm-v1.0.0.json";
+import tekuv1 from "../common/NodeSpecs/teku/teku-v1.0.0.json";
 
-import pathfinderv1 from '../common/NodeSpecs/pathfinder/pathfinder-v1.0.0.json';
+import pathfinderv1 from "../common/NodeSpecs/pathfinder/pathfinder-v1.0.0.json";
 
-import hildrv1 from '../common/NodeSpecs/hildr/hildr-v1.0.0.json';
-import magiv1 from '../common/NodeSpecs/magi/magi-v1.0.0.json';
-import opGethv1 from '../common/NodeSpecs/op-geth/op-geth-v1.0.0.json';
-import opNodev1 from '../common/NodeSpecs/op-node/op-node-v1.0.0.json';
+import hildrv1 from "../common/NodeSpecs/hildr/hildr-v1.0.0.json";
+import magiv1 from "../common/NodeSpecs/magi/magi-v1.0.0.json";
+import opGethv1 from "../common/NodeSpecs/op-geth/op-geth-v1.0.0.json";
+import opNodev1 from "../common/NodeSpecs/op-node/op-node-v1.0.0.json";
 
-import hubblev1 from '../common/NodeSpecs/hubble/hubble-v1.0.0.json';
+import hubblev1 from "../common/NodeSpecs/hubble/hubble-v1.0.0.json";
 
-import nitrov1 from '../common/NodeSpecs/nitro/nitro-v1.0.0.json';
+import nitrov1 from "../common/NodeSpecs/nitro/nitro-v1.0.0.json";
 
-import homeAssistantServicev1 from '../common/NodeSpecs/home-assistant-service/home-assistant-service-v1.0.0.json';
-import itzgMinecraftv1 from '../common/NodeSpecs/itzg-minecraft/itzg-minecraft-v1.0.0.json';
+import homeAssistantServicev1 from "../common/NodeSpecs/home-assistant-service/home-assistant-service-v1.0.0.json";
+import itzgMinecraftv1 from "../common/NodeSpecs/itzg-minecraft/itzg-minecraft-v1.0.0.json";
 
 import type {
   NodePackageSpecification,
   NodeSpecification,
   DockerExecution as PodmanExecution,
-} from '../common/nodeSpec';
-import logger from './logger';
+} from "../common/nodeSpec";
+import logger from "./logger";
 import {
   type NodeLibrary,
   type NodePackageLibrary,
   updateNodeLibrary,
   updateNodePackageLibrary,
-} from './state/nodeLibrary';
+} from "./state/nodeLibrary";
 
 export const initialize = async () => {
   // parse spec json for latest versions
@@ -83,21 +83,32 @@ export const initialize = async () => {
 
       // "inject" serviceVersion and dataDir (todo) here. Universal for all nodes.
       const execution = nodeSpec.execution as PodmanExecution;
-      let defaultImageTag = 'latest';
+      let defaultImageTag = "latest";
       // if the defaultImageTag is set in the spec use that, otherwise 'latest'
       if (execution.defaultImageTag !== undefined) {
         defaultImageTag = execution.defaultImageTag;
       }
 
+      nodeSpec.configTranslation.cliInput = {
+        displayName: `${spec.displayName} CLI Input`,
+        uiControl: {
+          type: "text",
+        },
+        defaultValue: "",
+        addNodeFlow: "advanced",
+        infoDescription:
+          "Enter any direct CLI input to the node start command.",
+      };
+
       nodeSpec.configTranslation.serviceVersion = {
         displayName: `${spec.displayName} version`,
         uiControl: {
-          type: 'text',
+          type: "text",
         },
         defaultValue: defaultImageTag,
-        addNodeFlow: 'advanced',
+        addNodeFlow: "advanced",
         infoDescription:
-          'Caution Advised! Example value: latest, v1.0.0, stable. Consult service documentation for available versions.',
+          "Caution Advised! Example value: latest, v1.0.0, stable. Consult service documentation for available versions.",
       };
 
       nodeSpecBySpecId[spec.specId] = nodeSpec;

--- a/src/main/nodeLibraryManager.ts
+++ b/src/main/nodeLibraryManager.ts
@@ -81,7 +81,7 @@ export const initialize = async () => {
         nodeSpec.configTranslation = {};
       }
 
-      // 'inject' serviceVersion and dataDir (todo) here. Universal for all nodes.
+      // "inject" serviceVersion and dataDir (todo) here. Universal for all nodes.
       const execution = nodeSpec.execution as PodmanExecution;
       let defaultImageTag = 'latest';
       // if the defaultImageTag is set in the spec use that, otherwise 'latest'
@@ -90,14 +90,13 @@ export const initialize = async () => {
       }
 
       nodeSpec.configTranslation.cliInput = {
-        displayName: `${spec.displayName} CLI Input`,
+        displayName: `${spec.displayName} CLI input`,
         uiControl: {
           type: 'text',
         },
-        defaultValue: ',
+        defaultValue: '',
         addNodeFlow: 'advanced',
-        infoDescription:
-          'Enter any direct CLI input to the node start command.',
+        infoDescription: 'Additional CLI input',
       };
 
       nodeSpec.configTranslation.serviceVersion = {


### PR DESCRIPTION
## Description
Allow users to input any direct CLI input to the node start command. 

## Reference Screenshots of implementation

![Screenshot 2024-05-22 232035](https://github.com/NiceNode/nice-node/assets/94786511/9902b9af-dc6c-4f1e-831f-680ab18bbb83)

### Checklist

- [x] Available on every service without having to put it in .json. Similar to image version input
- [x] Available as advanced setting in the Add Node flow
- [x] Put it just above the version input

### Solves Issue
#568 