### PR TITLE
fix: op and base node init files no longer necessary

### DIFF
--- a/src/common/NodeSpecs/base/base-v1.0.0.json
+++ b/src/common/NodeSpecs/base/base-v1.0.0.json
@@ -10,16 +10,14 @@
         "name": "Execution Client",
         "nodeOptions": ["op-geth", "nethermind"],
         "required": true,
-        "requiresCommonJwtSecret": true,
-        "requiresFiles": true
+        "requiresCommonJwtSecret": true
       },
       {
         "serviceId": "consensusClient",
         "name": "Consensus Client",
         "nodeOptions": ["op-node", "magi", "hildr"],
         "required": true,
-        "requiresCommonJwtSecret": true,
-        "requiresFiles": true
+        "requiresCommonJwtSecret": true
       }
     ],
     "dependencies": [

--- a/src/common/NodeSpecs/optimism/optimism-v1.0.0.json
+++ b/src/common/NodeSpecs/optimism/optimism-v1.0.0.json
@@ -11,16 +11,14 @@
         "name": "Execution Client",
         "nodeOptions": ["op-geth", "nethermind"],
         "required": true,
-        "requiresCommonJwtSecret": true,
-        "requiresFiles": true
+        "requiresCommonJwtSecret": true
       },
       {
         "serviceId": "consensusClient",
         "name": "Consensus Client",
         "nodeOptions": ["op-node", "magi", "hildr"],
         "required": true,
-        "requiresCommonJwtSecret": true,
-        "requiresFiles": true
+        "requiresCommonJwtSecret": true
       }
     ],
     "dependencies": [


### PR DESCRIPTION
Only custom networks need genesis files. Also, the files need to be copied in vite build. However, this arch is changing in the near future, so not fixing copy in build now.