### PR TITLE
fix: user configured settings persistence on add node flow

### DIFF
--- a/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/AddNodeConfiguration.tsx
@@ -104,6 +104,20 @@ const AddNodeConfiguration = ({
   const [sNodePackageConfigValues, dispatchNodePackageConfigValues] =
     useReducer(mergeObjectReducer, {});
 
+  const onChangeClientConfigValues = (value: any) => {
+    dispatchClientConfigValues(value);
+    setTemporaryClientConfigValues({
+      payload: value,
+    });
+  };
+
+  const onChangeNodePackageConfigValues = (value: any) => {
+    dispatchNodePackageConfigValues(value);
+    setTemporaryClientConfigValues({
+      payload: value,
+    });
+  };
+
   const [
     sNodeStorageLocationFreeStorageGBs,
     setNodeStorageLocationFreeStorageGBs,
@@ -278,7 +292,10 @@ const AddNodeConfiguration = ({
       const defaultNodesStorageDetails =
         await electron.getNodesDefaultStorageLocation();
       console.log('defaultNodesStorageDetails', defaultNodesStorageDetails);
-      setNodeStorageLocation(defaultNodesStorageDetails.folderPath);
+      setNodeStorageLocation(
+        tempConfigValues?.storageLocation ||
+          defaultNodesStorageDetails.folderPath,
+      );
       if (onChange) {
         onChange({
           clientSelections: sClientSelections,
@@ -400,6 +417,11 @@ const AddNodeConfiguration = ({
                     storageLocation: storageLocationDetails.folderPath,
                   });
                 }
+                setTemporaryClientConfigValues({
+                  payload: {
+                    storageLocation: storageLocationDetails.folderPath,
+                  },
+                });
                 setNodeStorageLocationFreeStorageGBs(
                   storageLocationDetails.freeStorageGBs,
                 );
@@ -417,19 +439,21 @@ const AddNodeConfiguration = ({
         {/* Initial node package settings, required */}
         {requiredNodePackageSpecs.length > 0 && (
           <InitialClientConfigs
+            tempConfigValues={tempConfigValues}
             clientSpecs={requiredNodePackageSpecs}
             required
             disableSaveButton={disableSaveButton}
-            onChange={dispatchNodePackageConfigValues}
+            onChange={onChangeNodePackageConfigValues}
           />
         )}
         {/* Initial client settings, required */}
         {requiredClientSpecs.length > 0 && (
           <InitialClientConfigs
+            tempConfigValues={tempConfigValues}
             clientSpecs={requiredClientSpecs}
             required
             disableSaveButton={disableSaveButton}
-            onChange={dispatchClientConfigValues}
+            onChange={onChangeClientConfigValues}
           />
         )}
         {sIsAdvancedOptionsOpen && (
@@ -437,16 +461,18 @@ const AddNodeConfiguration = ({
             {/* Initial node package settings, advanced */}
             {advancedNodePackageSpecs.length > 0 && (
               <InitialClientConfigs
+                tempConfigValues={tempConfigValues}
                 clientSpecs={advancedNodePackageSpecs}
-                onChange={dispatchNodePackageConfigValues}
+                onChange={onChangeNodePackageConfigValues}
               />
             )}
 
             {/* Initial client settings, advanced */}
             {advancedClientSpecs.length > 0 && (
               <InitialClientConfigs
+                tempConfigValues={tempConfigValues}
                 clientSpecs={advancedClientSpecs}
-                onChange={dispatchClientConfigValues}
+                onChange={onChangeClientConfigValues}
               />
             )}
           </>

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -139,7 +139,7 @@ const InitialClientConfigs = ({
       {Object.keys(sClientConfigTranslations).map((clientId: string) => {
         const clientConfigTranslation = sClientConfigTranslations[clientId];
         const singleClientConfigValues =
-          tempConfigValues[clientSpecs[0].specId] ||
+          tempConfigValues[clientId] ||
           (sClientConfigValues as ConfigValuesMap)[clientId] ||
           {};
 

--- a/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
+++ b/src/renderer/Presentational/AddNodeConfiguration/InitialClientConfigs.tsx
@@ -20,6 +20,7 @@ export type ClientConfigTranslations = {
 };
 
 export interface InitialClientConfigsProps {
+  tempConfigValues: ConfigValuesMap;
   clientSpecs: NodeSpecification[];
   required?: boolean;
   disableSaveButton?: (value: boolean) => void;
@@ -27,6 +28,7 @@ export interface InitialClientConfigsProps {
 }
 
 const InitialClientConfigs = ({
+  tempConfigValues,
   clientSpecs,
   required = false,
   disableSaveButton = () => {},
@@ -137,7 +139,9 @@ const InitialClientConfigs = ({
       {Object.keys(sClientConfigTranslations).map((clientId: string) => {
         const clientConfigTranslation = sClientConfigTranslations[clientId];
         const singleClientConfigValues =
-          (sClientConfigValues as ConfigValuesMap)[clientId] || {};
+          tempConfigValues[clientSpecs[0].specId] ||
+          (sClientConfigValues as ConfigValuesMap)[clientId] ||
+          {};
 
         return (
           <React.Fragment key={clientId}>

--- a/src/renderer/Presentational/AddNodeConfiguration/deepMerge.ts
+++ b/src/renderer/Presentational/AddNodeConfiguration/deepMerge.ts
@@ -192,4 +192,14 @@ export const mergeObjectReducer = (state: object, action: object) => {
   return merge(state, action);
 };
 
+export const mergeObjectReducerWithReset = (
+  state: object,
+  action: { type?: string; payload?: { reset?: boolean } & object },
+) => {
+  if (action.payload?.reset) {
+    return {};
+  }
+  return merge(state, action.payload || {});
+};
+
 export default merge;

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepper.tsx
@@ -1,6 +1,6 @@
 // This component could be made into a Generic "FullScreenStepper" component
 // Just make sure to always render each child so that children component state isn't cleard
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useReducer } from 'react';
 
 import type { SystemRequirements } from '../../../common/systemRequirements';
 import type {
@@ -18,6 +18,7 @@ import NodeRequirements from '../NodeRequirements/NodeRequirements';
 import PodmanInstallation from '../PodmanInstallation/PodmanInstallation';
 import { componentContainer, container } from './addNodeStepper.css';
 import { mergeSystemRequirements } from './mergeNodeRequirements';
+import { mergeObjectReducerWithReset } from '../AddNodeConfiguration/deepMerge.js';
 
 import type { NodePackageSpecification } from '../../../common/nodeSpec';
 import type { AddNodePackageNodeService } from '../../../main/nodePackageManager';
@@ -51,6 +52,11 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
   const [sNodeRequirements, setEthereumNodeRequirements] =
     useState<SystemRequirements>();
   const [sNodeStorageLocation, setNodeStorageLocation] = useState<string>();
+  const [tempConfigValues, setTemporaryClientConfigValues] = useReducer(
+    mergeObjectReducerWithReset,
+    {},
+  );
+  const [selectedNode, setSelectedNode] = useState<string>('');
 
   // Load ALL node spec's when AddNodeStepper is created
   //  This can later be optimized to only retrieve NodeSpecs as needed
@@ -84,6 +90,10 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
         if (sNodeLibrary) {
           nodeReqs = sNodeLibrary?.[ecValue]?.systemRequirements;
         }
+      }
+      setSelectedNode(newValue);
+      if (selectedNode !== newValue) {
+        setTemporaryClientConfigValues({ payload: { reset: true } });
       }
       try {
         if (nodeReqs) {
@@ -261,6 +271,8 @@ const AddNodeStepper = ({ onChange, modal = false }: AddNodeStepperProps) => {
             nodePackageLibrary={sNodePackageLibrary}
             nodeId={sNode?.node?.value}
             onChange={onChangeAddNodeConfiguration}
+            tempConfigValues={tempConfigValues}
+            setTemporaryClientConfigValues={setTemporaryClientConfigValues}
           />
         );
         stepImage = step1;

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
@@ -49,6 +49,7 @@ const AddNodeStepperModal = ({
     mergeObjectReducerWithReset,
     {},
   );
+  const [selectedNode, setSelectedNode] = useState<string>('');
 
   const onChangeAddNodeConfiguration = (
     newValue: AddNodeConfigurationValues,
@@ -113,11 +114,14 @@ const AddNodeStepperModal = ({
       });
       // clear step 1 (client selections) when user changes node (package)
       setEthereumNodeConfig(undefined);
-      setTemporaryClientConfigValues({ payload: { reset: true } });
+      setSelectedNode(nodeSelectOption.value);
+      if (selectedNode !== nodeSelectOption.value) {
+        setTemporaryClientConfigValues({ payload: { reset: true } });
+      }
       console.log('AddNodeStepperModal setNode: config', config);
       setNodeConfig(config);
     },
-    [],
+    [selectedNode],
   );
 
   const onChangeDockerInstall = useCallback((newValue: string) => {

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
@@ -17,7 +17,7 @@ import NodeRequirements from '../NodeRequirements/NodeRequirements';
 import PodmanInstallation from '../PodmanInstallation/PodmanInstallation';
 import { componentContainer, container } from './addNodeStepper.css';
 import { mergeSystemRequirements } from './mergeNodeRequirements';
-import { mergeObjectReducer } from '../AddNodeConfiguration/deepMerge.js';
+import { mergeObjectReducerWithReset } from '../AddNodeConfiguration/deepMerge.js';
 
 export interface AddNodeStepperModalProps {
   modal?: boolean;
@@ -46,7 +46,7 @@ const AddNodeStepperModal = ({
   const [sNodeRequirements, setNodeRequirements] =
     useState<SystemRequirements>();
   const [tempConfigValues, setTemporaryClientConfigValues] = useReducer(
-    mergeObjectReducer,
+    mergeObjectReducerWithReset,
     {},
   );
 

--- a/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
+++ b/src/renderer/Presentational/AddNodeStepper/AddNodeStepperModal.tsx
@@ -1,6 +1,6 @@
 // This component could be made into a Generic "FullScreenStepper" component
 // Just make sure to always render each child so that children component state isn't cleard
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useReducer } from 'react';
 
 import type { SystemRequirements } from '../../../common/systemRequirements';
 import type {
@@ -17,6 +17,7 @@ import NodeRequirements from '../NodeRequirements/NodeRequirements';
 import PodmanInstallation from '../PodmanInstallation/PodmanInstallation';
 import { componentContainer, container } from './addNodeStepper.css';
 import { mergeSystemRequirements } from './mergeNodeRequirements';
+import { mergeObjectReducer } from '../AddNodeConfiguration/deepMerge.js';
 
 export interface AddNodeStepperModalProps {
   modal?: boolean;
@@ -44,6 +45,10 @@ const AddNodeStepperModal = ({
     useState<AddNodeConfigurationValues>();
   const [sNodeRequirements, setNodeRequirements] =
     useState<SystemRequirements>();
+  const [tempConfigValues, setTemporaryClientConfigValues] = useReducer(
+    mergeObjectReducer,
+    {},
+  );
 
   const onChangeAddNodeConfiguration = (
     newValue: AddNodeConfigurationValues,
@@ -108,6 +113,7 @@ const AddNodeStepperModal = ({
       });
       // clear step 1 (client selections) when user changes node (package)
       setEthereumNodeConfig(undefined);
+      setTemporaryClientConfigValues({ payload: { reset: true } });
       console.log('AddNodeStepperModal setNode: config', config);
       setNodeConfig(config);
     },
@@ -141,6 +147,8 @@ const AddNodeStepperModal = ({
             onChange={onChangeAddNodeConfiguration}
             disableSaveButton={disableSaveButton}
             shouldHideTitle
+            tempConfigValues={tempConfigValues}
+            setTemporaryClientConfigValues={setTemporaryClientConfigValues}
           />
         );
         break;


### PR DESCRIPTION
- keeps user configured settings in a temporary object, allowing users to go back and forth from node settings
- resets temporary object only if user changes initial node package to something else

fixes #408 