### PR TITLE
chore: electron 31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "@wdio/mocha-framework": "^8.36.1",
         "@wdio/spec-reporter": "^8.36.1",
         "cross-env": "^7.0.3",
-        "electron": "^30.0.1",
+        "electron": "^31.3.1",
         "electron-devtools-installer": "^3.2.0",
         "electron-extension-installer": "^1.2.0",
         "electron-mock-ipc": "^0.3.12",
@@ -12730,9 +12730,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.1.tgz",
-      "integrity": "sha512-iwxkI/n2wBd29NH7TH0ZY8aWGzCoKpzJz+D10u7aGSJi1TV6d4MSM3rWyKvT/UkAHkTKOEgYfUyCa2vWQm8L0g==",
+      "version": "31.3.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.3.1.tgz",
+      "integrity": "sha512-9fiuWlRhBfygtcT+auRd/WdBK/f8LZZcrpx0RjpXhH2DPTP/PfnkC4JB1PW55qCbGbh4wAgkYbf4ExIag8oGCA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@wdio/mocha-framework": "^8.36.1",
     "@wdio/spec-reporter": "^8.36.1",
     "cross-env": "^7.0.3",
-    "electron": "^30.0.1",
+    "electron": "^31.3.1",
     "electron-devtools-installer": "^3.2.0",
     "electron-extension-installer": "^1.2.0",
     "electron-mock-ipc": "^0.3.12",
@@ -125,7 +125,13 @@
     "url": "http://nicenode.xyz"
   },
   "license": "MIT",
-  "keywords": ["ethereum", "node", "blockchain", "web3", "local"],
+  "keywords": [
+    "ethereum",
+    "node",
+    "blockchain",
+    "web3",
+    "local"
+  ],
   "devEngines": {
     "node": ">=20.x",
     "npm": ">=9.x"

--- a/src/renderer/Presentational/Sidebar/sidebar.css.ts
+++ b/src/renderer/Presentational/Sidebar/sidebar.css.ts
@@ -13,12 +13,12 @@ export const container = style({
   height: '100%',
   backgroundColor: vars.components.sidebarBackground,
   // backdropFilter: 'blur(40px)',
-  selectors: {
-    '&.darwin': {
-      backgroundColor: 'transparent',
-      backdropFilter: 'blur(40px)',
-    },
-  },
+  // selectors: {
+  //   '&.darwin': {
+  //     backgroundColor: 'transparent',
+  //     backdropFilter: 'blur(40px)',
+  //   },
+  // },
 });
 
 export const titleItem = style({

--- a/src/renderer/app.css.ts
+++ b/src/renderer/app.css.ts
@@ -41,11 +41,11 @@ export const borderLeft = style({
   backgroundColor: vars.components.sidebarBackground,
   width: 3,
   height: '100%',
-  selectors: {
-    '&.darwin': {
-      backgroundColor: 'transparent',
-    },
-  },
+  // selectors: {
+  //   '&.darwin': {
+  //     backgroundColor: 'transparent',
+  //   },
+  // },
 });
 
 export const borderCenter = style({
@@ -59,11 +59,11 @@ export const borderCenterLine = style({
   backgroundColor: vars.components.sidebarBorder,
   height: '100%',
   width: 1,
-  selectors: {
-    '&.darwin': {
-      backgroundColor: vars.components.sidebarMacBorder,
-    },
-  },
+  // selectors: {
+  //   '&.darwin': {
+  //     backgroundColor: vars.components.sidebarMacBorder,
+  //   },
+  // },
 });
 
 export const borderRight = style({

--- a/src/renderer/themeManager.css.ts
+++ b/src/renderer/themeManager.css.ts
@@ -3,9 +3,9 @@ import { vars } from './Generics/redesign/theme.css';
 
 export const background = style({
   background: vars.color.background,
-  selectors: {
-    '&.darwin': {
-      background: 'none',
-    },
-  },
+  // selectors: {
+  //   '&.darwin': {
+  //     background: 'none',
+  //   },
+  // },
 });


### PR DESCRIPTION
Sidebar has issues and it flashes repeatedly and devtools don't work, however, disabling background-color: 'transparent' along with the blur fixes this.

Transparent background implementation seems to have changed in Electron 31 (or the Chrome version in Electron 31+). css `background-color: 'transparent'` leaves the sidebar white instead of showing the nice mac style transparency. I didn't find anything in the release docs that says the implementation changed, but on Electron's docs they note the limitations of `transparent: true` when creating a BrowserWindow here https://www.electronjs.org/docs/latest/tutorial/window-customization#create-transparent-windows

<img width="1064" alt="Screenshot 2024-07-30 at 5 11 46 PM" src="https://github.com/user-attachments/assets/85afcc5a-cd67-42fe-be0b-cda3dfa86b1f">

after disabling mac specific transparency:
<img width="1180" alt="Screenshot 2024-07-30 at 6 15 05 PM" src="https://github.com/user-attachments/assets/94465686-bf04-40b8-a533-e56be050ca01">
<img width="1180" alt="Screenshot 2024-07-30 at 6 15 01 PM" src="https://github.com/user-attachments/assets/3f25afeb-1836-4c3c-b7e3-044d8f64594d">

