### PR TITLE
chore: electron v32 and re-enabled mac transparency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "@wdio/mocha-framework": "^8.36.1",
         "@wdio/spec-reporter": "^8.36.1",
         "cross-env": "^7.0.3",
-        "electron": "^31.3.1",
+        "electron": "^32.0.0",
         "electron-devtools-installer": "^3.2.0",
         "electron-extension-installer": "^1.2.0",
         "electron-mock-ipc": "^0.3.12",
@@ -12730,9 +12730,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.3.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.3.1.tgz",
-      "integrity": "sha512-9fiuWlRhBfygtcT+auRd/WdBK/f8LZZcrpx0RjpXhH2DPTP/PfnkC4JB1PW55qCbGbh4wAgkYbf4ExIag8oGCA==",
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-32.0.0.tgz",
+      "integrity": "sha512-rs+VkhztJd2LvRX7d3ikKH+EIHMW4vKM2l5qp7Dx/dLQAKKz3IFNKyYhYzczDnqO+/jUvx0ic0SQvqpv1/ZAsw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@wdio/mocha-framework": "^8.36.1",
     "@wdio/spec-reporter": "^8.36.1",
     "cross-env": "^7.0.3",
-    "electron": "^31.3.1",
+    "electron": "^32.0.0",
     "electron-devtools-installer": "^3.2.0",
     "electron-extension-installer": "^1.2.0",
     "electron-mock-ipc": "^0.3.12",

--- a/src/renderer/Presentational/Sidebar/sidebar.css.ts
+++ b/src/renderer/Presentational/Sidebar/sidebar.css.ts
@@ -12,13 +12,13 @@ export const container = style({
   width: '268px',
   height: '100%',
   backgroundColor: vars.components.sidebarBackground,
-  // backdropFilter: 'blur(40px)',
-  // selectors: {
-  //   '&.darwin': {
-  //     backgroundColor: 'transparent',
-  //     backdropFilter: 'blur(40px)',
-  //   },
-  // },
+  backdropFilter: 'blur(40px)',
+  selectors: {
+    '&.darwin': {
+      backgroundColor: 'transparent',
+      backdropFilter: 'blur(40px)',
+    },
+  },
 });
 
 export const titleItem = style({

--- a/src/renderer/app.css.ts
+++ b/src/renderer/app.css.ts
@@ -41,11 +41,11 @@ export const borderLeft = style({
   backgroundColor: vars.components.sidebarBackground,
   width: 3,
   height: '100%',
-  // selectors: {
-  //   '&.darwin': {
-  //     backgroundColor: 'transparent',
-  //   },
-  // },
+  selectors: {
+    '&.darwin': {
+      backgroundColor: 'transparent',
+    },
+  },
 });
 
 export const borderCenter = style({
@@ -59,11 +59,11 @@ export const borderCenterLine = style({
   backgroundColor: vars.components.sidebarBorder,
   height: '100%',
   width: 1,
-  // selectors: {
-  //   '&.darwin': {
-  //     backgroundColor: vars.components.sidebarMacBorder,
-  //   },
-  // },
+  selectors: {
+    '&.darwin': {
+      backgroundColor: vars.components.sidebarMacBorder,
+    },
+  },
 });
 
 export const borderRight = style({

--- a/src/renderer/themeManager.css.ts
+++ b/src/renderer/themeManager.css.ts
@@ -3,9 +3,9 @@ import { vars } from './Generics/redesign/theme.css';
 
 export const background = style({
   background: vars.color.background,
-  // selectors: {
-  //   '&.darwin': {
-  //     background: 'none',
-  //   },
-  // },
+  selectors: {
+    '&.darwin': {
+      background: 'none',
+    },
+  },
 });


### PR DESCRIPTION
The transparency bug introduced in electron 31 has been fixed and is detailed here:
https://github.com/electron/electron/issues/42335. It was fixed in electron 31 and 32. 